### PR TITLE
Fix CI feed URL, use build variable if present

### DIFF
--- a/src/Directory.props
+++ b/src/Directory.props
@@ -9,6 +9,8 @@
     <NoWarn>CS0436;$(NoWarn)</NoWarn>
     <!-- Clear suffix to get clean 42.42.* versions from main for easier install/update -->
     <VersionSuffix Condition="$(VersionSuffix) == 'main'"></VersionSuffix>
+    <!-- CI variable with feed URL -->
+    <SLEET_FEED_URL Condition="$(SLEET_FEED_URL) == ''">https://clarius.blob.core.windows.net/nuget/index.json</SLEET_FEED_URL>
   </PropertyGroup>
   
 </Project>

--- a/src/dotnet-openlaw/Program.cs
+++ b/src/dotnet-openlaw/Program.cs
@@ -71,7 +71,7 @@ static async Task<string[]> CheckUpdates(string[] args)
     var repository = new SourceRepository(new PackageSource(
         // use CI feed rather than production feed depending on which version we're using
         civersion ?
-        "https://kzu.blob.core.windows.net/nuget/index.json" :
+        ThisAssembly.Project.SLEET_FEED_URL :
         "https://api.nuget.org/v3/index.json"), providers);
     var resource = await repository.GetResourceAsync<PackageMetadataResource>();
     var localVersion = new NuGetVersion(ThisAssembly.Project.Version);

--- a/src/dotnet-openlaw/dotnet-openlaw.csproj
+++ b/src/dotnet-openlaw/dotnet-openlaw.csproj
@@ -21,6 +21,7 @@
     <ProjectProperty Include="BuildRef" />
     <ProjectProperty Include="PackageId" />
     <ProjectProperty Include="PackageVersion" />
+    <ProjectProperty Include="SLEET_FEED_URL" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
We configure this at the repo/org level to determine where to push the CI package to, using sleet. By reusing the same property in the project, we can ensure it's kept in sync with how it's published from CI builds.