### PR TITLE
Don't hardcode CI feed URL

### DIFF
--- a/src/dotnet-openlaw/Program.cs
+++ b/src/dotnet-openlaw/Program.cs
@@ -96,7 +96,7 @@ static async Task<string[]> CheckUpdates(string[] args)
         return [
             $"Hay una nueva version de [yellow]{ThisAssembly.Project.PackageId}[/]: [dim]v{localVersion.ToNormalizedString()}[/] -> [lime]v{update.ToNormalizedString()}[/]",
             $"Actualizar con: [yellow]dotnet[/] tool update -g {ThisAssembly.Project.PackageId}" +
-            (civersion ? " --source https://kzu.blob.core.windows.net/nuget/index.json" : ""),
+            (civersion ? " --source " + ThisAssembly.Project.SLEET_FEED_URL : ""),
         ];
     }
 


### PR DESCRIPTION
Use the same project-generated constant used for checking for updates in the rendered message for updating.

This was a bug from the previously hardcoded feed.