### PR TITLE
Fix bug in enum parsing when using TryParse

### DIFF
--- a/src/OpenLaw/DisplayValue.cs
+++ b/src/OpenLaw/DisplayValue.cs
@@ -8,6 +8,9 @@ public static class DisplayValue
     public static T Parse<T>(string value, bool ignoreCase = false) where T : struct, Enum
         => DisplayValue<T>.Parse(value, ignoreCase);
 
-    public static bool TryParse<T>(string value, out T result, bool ignoreCase = false) where T : struct, Enum
-        => DisplayValue<T>.TryParse(value, out result, ignoreCase);
+    public static bool TryParse<T>(string value, out T result) where T : struct, Enum
+        => DisplayValue<T>.TryParse(value, false, out result);
+
+    public static bool TryParse<T>(string value, bool ignoreCase, out T result) where T : struct, Enum
+        => DisplayValue<T>.TryParse(value, ignoreCase, out result);
 }

--- a/src/OpenLaw/DisplayValue`1.cs
+++ b/src/OpenLaw/DisplayValue`1.cs
@@ -40,7 +40,9 @@ static class DisplayValue<T> where T : struct, Enum
         return Enum.Parse<T>(value, ignoreCase);
     }
 
-    public static bool TryParse(string? value, out T result, bool ignoreCase = false)
+    public static bool TryParse(string? value, out T result) => TryParse(value, false, out result);
+
+    public static bool TryParse(string? value, bool ignoreCase, out T result)
     {
         if (value == null)
         {
@@ -52,6 +54,6 @@ static class DisplayValue<T> where T : struct, Enum
         if (map.TryGetValue(value, out result))
             return true;
 
-        return map.TryGetValue(value, out result);
+        return Enum.TryParse(value, ignoreCase, out result);
     }
 }

--- a/src/Tests/DisplayValueTests.cs
+++ b/src/Tests/DisplayValueTests.cs
@@ -39,6 +39,34 @@ public class DisplayValueTests
         Assert.Equal(Foo.Bar, foo);
     }
 
+    [Fact]
+    public void CanTryParseFromDisplay()
+    {
+        Assert.True(DisplayValue.TryParse<Foo>("The Bar", out var foo));
+        Assert.Equal(Foo.Bar, foo);
+    }
+
+    [Fact]
+    public void CanTryParseFromSecondDisplay()
+    {
+        Assert.True(DisplayValue.TryParse<Foo>("Second", out var foo));
+        Assert.Equal(Foo.Baz, foo);
+    }
+
+    [Fact]
+    public void CanTryParseCaseInsensitive()
+    {
+        Assert.True(DisplayValue.TryParse<Foo>("the bar", true, out var foo));
+        Assert.Equal(Foo.Bar, foo);
+    }
+
+    [Fact]
+    public void CanTryParseDirectEnum()
+    {
+        Assert.True(DisplayValue.TryParse<Foo>(nameof(Foo.Bar), out var foo));
+        Assert.Equal(Foo.Bar, foo);
+    }
+
     public enum Foo
     {
         [DisplayValue("The Bar")]


### PR DESCRIPTION
This also aligns the ignoreCase parameter order/overloads with the way Enum.TryParse works.