### PR TITLE
Expose SAIJ ID in addition to document UUID

### DIFF
--- a/src/OpenLaw/Argentina/Document.cs
+++ b/src/OpenLaw/Argentina/Document.cs
@@ -47,9 +47,6 @@ public class Document
     public string Json { get; }
     public Dictionary<string, object?>? Dictionary => dictionary;
 
-    public string HtmlUrl => $"https://www.saij.gob.ar/{Id}";
-    public string JsonUrl => $"https://www.saij.gob.ar/view-document?guid={Id}";
-
     public async Task<DocumentAbstract?> GetAbstractAsync()
     {
         // We only need to attempt metadata conversion once
@@ -128,5 +125,5 @@ public class Document
             """ : markdown;
     }
 
-    public override string ToString() => $"[{Id}]({HtmlUrl})";
+    public override string ToString() => $"[{Id}](https://www.saij.gob.ar/{Id})";
 }

--- a/src/OpenLaw/Argentina/DownloadCommand.cs
+++ b/src/OpenLaw/Argentina/DownloadCommand.cs
@@ -51,7 +51,7 @@ public class DownloadCommand(IAnsiConsole console, IHttpClientFactory http) : As
 
                 await Parallel.ForEachAsync(client.SearchAsync(), options, async (doc, cancellation) =>
                 {
-                    var file = Path.Combine(settings.Directory, doc.Id + ".json");
+                    var file = Path.Combine(settings.Directory, doc.Uuid + ".json");
                     // Skip if file exists and has the same timestamp
                     if (File.Exists(file) && await GetJsonTimestampAsync(file) == doc.Timestamp)
                     {
@@ -68,7 +68,7 @@ public class DownloadCommand(IAnsiConsole console, IHttpClientFactory http) : As
                     }
 
                     // Converting to dictionary performs string multiline formatting and markup removal
-                    var full = await client.FetchAsync(doc.Id);
+                    var full = await client.FetchAsync(doc.Uuid);
                     File.WriteAllText(file, full.Json);
                     if (settings.Convert)
                         Convert(file, overwrite: true);

--- a/src/OpenLaw/Argentina/EnumerateCommand.cs
+++ b/src/OpenLaw/Argentina/EnumerateCommand.cs
@@ -86,13 +86,13 @@ public class EnumerateCommand(IAnsiConsole console, IHttpClientFactory http) : A
                     {
                         try
                         {
-                            var full = await client.FetchAsync(doc.Id);
+                            var full = await client.FetchAsync(doc.Uuid);
                             var json = await JQ.ExecuteAsync(full.Json, ".document.content.d_link // empty");
                             if (string.IsNullOrEmpty(json))
                                 return;
 
-                            AnsiConsole.MarkupInterpolated($":link: [blue][link={doc.JsonUrl}]{doc.Id}[/][/] \r\n[dim]{json}[/]");
-                            await File.AppendAllTextAsync("links.txt", $"[InlineData(\"{doc.Id}\")]\r\n", cancellation);
+                            AnsiConsole.MarkupInterpolated($":link: [blue][link={doc.DataUrl}]{doc.Uuid}[/][/] \r\n[dim]{json}[/]");
+                            await File.AppendAllTextAsync("links.txt", $"[InlineData(\"{doc.Uuid}\")]\r\n", cancellation);
                         }
                         catch (Exception e)
                         {

--- a/src/OpenLaw/Argentina/SaijAbstract.jq
+++ b/src/OpenLaw/Argentina/SaijAbstract.jq
@@ -1,5 +1,5 @@
 ﻿.document | {
-    id: .metadata.uuid,
+    uuid: .metadata.uuid,
     number: (.content["numero-norma"] // .content["numero_norma"] // null), 
     title: (.content["titulo-norma"] // .content["titulo_noticia"] // null),
     summary: (.content.sintesis // ([.content.sumario | .. | select(type == "string")] | join(""))),

--- a/src/OpenLaw/Argentina/SaijDocument.jq
+++ b/src/OpenLaw/Argentina/SaijDocument.jq
@@ -1,5 +1,6 @@
 .document | {
-    id: .metadata.uuid,
+    id: (.content["id-infojus"] // .metadata.uuid),
+    uuid: .metadata.uuid,
     ref: .content["standard-normativo"],
     name: .content["nombre-coloquial"] | tostring,
     number: (.content["numero-norma"] // .content["numero_norma"] // null), 

--- a/src/OpenLaw/Argentina/SaijIdType.jq
+++ b/src/OpenLaw/Argentina/SaijIdType.jq
@@ -1,4 +1,5 @@
 ﻿.document | {
-    id: .metadata.uuid,
+    id: (.content["id-infojus"] // .metadata.uuid),
+    uuid: .metadata.uuid,
     type: .metadata["document-content-type"]
 }

--- a/src/OpenLaw/Argentina/SaijSearch.jq
+++ b/src/OpenLaw/Argentina/SaijSearch.jq
@@ -4,7 +4,7 @@
     skip: .queryObjectData.offset,
     take: .queryObjectData.pageSize,
     docs: [.searchResults.documentResultList[] | {
-        id: .uuid,
+        uuid: .uuid,
         abstract: .documentAbstract
     }]
 }

--- a/src/OpenLaw/Argentina/SyncCommand.cs
+++ b/src/OpenLaw/Argentina/SyncCommand.cs
@@ -1,0 +1,45 @@
+﻿using System.ComponentModel;
+using System.Text.Json.Serialization;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace Clarius.OpenLaw.Argentina;
+
+public class SyncCommand : AsyncCommand<SyncCommand.SyncSettings>
+{
+    public override Task<int> ExecuteAsync(CommandContext context, SyncSettings settings)
+    {
+
+        return Task.FromResult(0);
+    }
+
+    public class SyncSettings : CommandSettings
+    {
+        [Description("Ubicación opcional archivos. Por defecto el directorio actual.")]
+        [CommandOption("--dir")]
+        public string Directory { get; set; } = System.IO.Directory.GetCurrentDirectory();
+
+        [Description("Tipo de norma a sincronizar.")]
+        [CommandOption("-t|--tipo")]
+        public TipoNorma Tipo { get; set; } = TipoNorma.Ley;
+
+        [Description("Jurisdicción a sincronizar.")]
+        [CommandOption("-j|--jurisdiccion")]
+        public Jurisdiccion Jurisdiccion { get; set; } = Jurisdiccion.Nacional;
+
+        [Description("Provincia a sincronizar.")]
+        [CommandOption("-p|--provincia")]
+        public Provincia? Provincia { get; set; }
+
+        public override ValidationResult Validate()
+        {
+            if (Jurisdiccion == Jurisdiccion.Provincial && Provincia == null)
+                return ValidationResult.Error("Debe especificar una provincia para la jurisdicción provincial.");
+
+            if (Jurisdiccion != Jurisdiccion.Provincial && Provincia != null)
+                return ValidationResult.Error("No se puede especificar una provincia para la jurisdicción no provincial.");
+
+            return base.Validate();
+        }
+    }
+}

--- a/src/Tests/Argentina/SaijClientExtensions.cs
+++ b/src/Tests/Argentina/SaijClientExtensions.cs
@@ -15,7 +15,7 @@ public static class SaijClientExtensions
     {
         await foreach (var doc in client.SearchAsync(tipo, jurisdiccion, provincia, skip, take, cancellation))
         {
-            if (await client.FetchJsonAsync(doc.Id) is not { } json)
+            if (await client.FetchJsonAsync(doc.Uuid) is not { } json)
                 continue;
 
             yield return json;


### PR DESCRIPTION
When searching, the results contain just latter, whereas full document loading contains both. The former is better for shorter links and filenames, while the latter is required to retrieve full document data.

We improve the FetchAsync method to support fetching by the shorter SAIJ ID too by performing a quick search. Using these IDs would then necessarily be a bit slower, but the benefit is a better UEX in some scenarios.

We update the markdown rendering to include selected properties as-is so that the resulting dictionary can be merged as-is with the front-matter at the end of the document without conflicts or duplication.

We also add both IDs at the end the front-matter since in GitHub it will go at the end of a scrollbar anyway and not be too much of a rendering issue, while we can use them to avoid reading entire file contents just to retrieve those values.

The included timestamp will also help in the sync process to come.