### PR TITLE
Add basic cross-repository sync interfaces and core implementation

### DIFF
--- a/src/OpenLaw/Argentina/DownloadCommand.cs
+++ b/src/OpenLaw/Argentina/DownloadCommand.cs
@@ -51,7 +51,7 @@ public class DownloadCommand(IAnsiConsole console, IHttpClientFactory http) : As
 
                 await Parallel.ForEachAsync(client.SearchAsync(), options, async (doc, cancellation) =>
                 {
-                    var file = Path.Combine(settings.Directory, doc.Uuid + ".json");
+                    var file = Path.Combine(settings.Directory, doc.Id + ".json");
                     // Skip if file exists and has the same timestamp
                     if (File.Exists(file) && await GetJsonTimestampAsync(file) == doc.Timestamp)
                     {
@@ -68,7 +68,7 @@ public class DownloadCommand(IAnsiConsole console, IHttpClientFactory http) : As
                     }
 
                     // Converting to dictionary performs string multiline formatting and markup removal
-                    var full = await client.FetchAsync(doc.Uuid);
+                    var full = await client.FetchAsync(doc.Id);
                     File.WriteAllText(file, full.Json);
                     if (settings.Convert)
                         Convert(file, overwrite: true);

--- a/src/OpenLaw/Argentina/EnumerateCommand.cs
+++ b/src/OpenLaw/Argentina/EnumerateCommand.cs
@@ -86,13 +86,13 @@ public class EnumerateCommand(IAnsiConsole console, IHttpClientFactory http) : A
                     {
                         try
                         {
-                            var full = await client.FetchAsync(doc.Uuid);
+                            var full = await client.FetchAsync(doc.Id);
                             var json = await JQ.ExecuteAsync(full.Json, ".document.content.d_link // empty");
                             if (string.IsNullOrEmpty(json))
                                 return;
 
-                            AnsiConsole.MarkupInterpolated($":link: [blue][link={doc.DataUrl}]{doc.Uuid}[/][/] \r\n[dim]{json}[/]");
-                            await File.AppendAllTextAsync("links.txt", $"[InlineData(\"{doc.Uuid}\")]\r\n", cancellation);
+                            AnsiConsole.MarkupInterpolated($":link: [blue][link={doc.DataUrl}]{doc.Id}[/][/] \r\n[dim]{json}[/]");
+                            await File.AppendAllTextAsync("links.txt", $"[InlineData(\"{doc.Id}\")]\r\n", cancellation);
                         }
                         catch (Exception e)
                         {

--- a/src/OpenLaw/Argentina/Model.cs
+++ b/src/OpenLaw/Argentina/Model.cs
@@ -20,29 +20,29 @@ public record Kind(string Code, string Text);
 public record Source(TipoNorma? Tipo, Jurisdiccion? Jurisdiccion, Provincia? Provincia);
 
 public record DocumentAbstract(
-    string Uuid,
+    string Id,
     string Title, string Summary,
     ContentType Type, Kind Kind, string Status, string Date,
-    string Modified, long Timestamp)
+    string Modified, long Timestamp) : IContentInfo
 {
     [JsonIgnore]
     public Source Source { get; init; } = new(null, null, null);
 
-    public virtual string WebUrl => $"https://www.saij.gob.ar/{Uuid}";
-    public string DataUrl => $"https://www.saij.gob.ar/view-document?guid={Uuid}";
+    public virtual string WebUrl => $"https://www.saij.gob.ar/{Id}";
+    public string DataUrl => $"https://www.saij.gob.ar/view-document?guid={Id}";
 };
 
 public record Legislation(
-    string Id, string Uuid, string Ref,
+    string Id, string Alias, string Ref,
     string Name, string Title, string Summary,
     ContentType Type, Kind Kind,
     string Status, string Date,
     string Modified, long Timestamp,
     string[] Terms,
     [property: JsonPropertyName("pub")] Publication? Publication) :
-    DocumentAbstract(Uuid, Title, Summary, Type, Kind, Status, Date, Modified, Timestamp)
+    DocumentAbstract(Id, Title, Summary, Type, Kind, Status, Date, Modified, Timestamp)
 {
-    public override string WebUrl => $"https://www.saij.gob.ar/{Id}";
+    public override string WebUrl => $"https://www.saij.gob.ar/{Alias}";
 }
 
 public record Publication([property: JsonPropertyName("org")] string Organization, string Date);
@@ -73,9 +73,9 @@ public static class DocumentExtensions
         fm.Add(nameof(doc.DataUrl), doc.DataUrl);
 
         if (full != null)
-            fm.Add(nameof(full.Id), full.Id);
+            fm.Add(nameof(full.Alias), full.Alias);
 
-        fm.Add(nameof(doc.Uuid), doc.Uuid);
+        fm.Add(nameof(doc.Id), doc.Id);
         fm.Add(nameof(doc.Timestamp), doc.Timestamp);
 
         return fm.ToYaml();

--- a/src/OpenLaw/Argentina/SaijAbstract.jq
+++ b/src/OpenLaw/Argentina/SaijAbstract.jq
@@ -1,5 +1,5 @@
 ﻿.document | {
-    uuid: .metadata.uuid,
+    id: .metadata.uuid,
     number: (.content["numero-norma"] // .content["numero_norma"] // null), 
     title: (.content["titulo-norma"] // .content["titulo_noticia"] // null),
     summary: (.content.sintesis // ([.content.sumario | .. | select(type == "string")] | join(""))),

--- a/src/OpenLaw/Argentina/SaijDocument.jq
+++ b/src/OpenLaw/Argentina/SaijDocument.jq
@@ -1,6 +1,6 @@
 .document | {
-    id: (.content["id-infojus"] // .metadata.uuid),
-    uuid: .metadata.uuid,
+    id: .metadata.uuid,
+    alias: (.content["id-infojus"] // .metadata.uuid),
     ref: .content["standard-normativo"],
     name: .content["nombre-coloquial"] | tostring,
     number: (.content["numero-norma"] // .content["numero_norma"] // null), 

--- a/src/OpenLaw/ContentAction.cs
+++ b/src/OpenLaw/ContentAction.cs
@@ -1,0 +1,20 @@
+﻿namespace Clarius.OpenLaw;
+
+/// <summary>
+/// The action performed by <see cref="IContentRepository.SetContentAsync(string, long, Stream)"/>.
+/// </summary>
+public enum ContentAction
+{
+    /// <summary>
+    /// The given content didn't exist and was created.
+    /// </summary>
+    Created,
+    /// <summary>
+    /// The given content existed and was updated since the timestamps didn't match.
+    /// </summary>
+    Updated,
+    /// <summary>
+    /// The given content existed but the timestamps matched, so it wasn't updated.
+    /// </summary>
+    Skipped,
+}

--- a/src/OpenLaw/ContentInfo.cs
+++ b/src/OpenLaw/ContentInfo.cs
@@ -1,0 +1,69 @@
+﻿using System.Text;
+using SharpYaml.Serialization;
+
+namespace Clarius.OpenLaw;
+
+public class ContentInfo(string id, long timestamp) : IContentInfo
+{
+    static readonly Serializer serializer = new();
+
+    public string Id { get; init; } = id;
+    public long Timestamp { get; init; } = timestamp;
+
+    public static IContentInfo? ReadFrontMatter(Stream stream)
+    {
+        using var reader = new StreamReader(stream);
+        var frontMatter = new StringBuilder();
+        var line = reader.ReadLine();
+        // First line must be the front-matter according to spec.
+        if (line == "---")
+        {
+            while ((line = reader.ReadLine()) != "---")
+            {
+                frontMatter.AppendLine(line);
+            }
+        }
+        else if (line == "<!--")
+        {
+            while ((line = reader.ReadLine()) != "-->")
+            {
+                frontMatter.AppendLine(line);
+            }
+        }
+        else
+        {
+            return null;
+        }
+
+        return serializer.Deserialize<FrontMatterContentInfo>(frontMatter.ToString());
+    }
+
+    public string ToFrontMatter(FrontMatter style = FrontMatter.Markdown)
+    {
+        var yaml = serializer.Serialize(this);
+
+        return style switch
+        {
+            FrontMatter.Markdown =>
+                $"""
+                ---
+                {yaml}
+                ---
+                """,
+            FrontMatter.Html =>
+                $"""
+                <!--
+                {yaml}
+                -->
+                """,
+            _ => yaml
+        };
+    }
+
+    class FrontMatterContentInfo : IContentInfo
+    {
+        public required string Id { get; init; }
+
+        public required long Timestamp { get; init; }
+    }
+}

--- a/src/OpenLaw/FileContentRepository.cs
+++ b/src/OpenLaw/FileContentRepository.cs
@@ -1,0 +1,76 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace Clarius.OpenLaw;
+
+/// <summary>
+/// A file-based <see cref="IContentRepository"/> implementation that uses 
+/// yaml front-matter (both at the beginning or the end of the file) 
+/// to store metadata alongside the content.
+/// </summary>
+public class FileContentRepository : IContentRepository
+{
+    readonly string baseDir;
+
+    public FileContentRepository(string baseDir)
+    {
+        this.baseDir = baseDir;
+        Directory.CreateDirectory(baseDir);
+    }
+
+    public async IAsyncEnumerable<IContentInfo> EnumerateAsync([EnumeratorCancellation] CancellationToken cancellation)
+    {
+        foreach (var file in Directory.EnumerateFiles(baseDir, "*.md"))
+        {
+            cancellation.ThrowIfCancellationRequested();
+            using var stream = File.OpenRead(file);
+            if (ContentInfo.ReadFrontMatter(stream) is { } info)
+            {
+                yield return info;
+                await Task.Yield();
+            }
+        }
+    }
+
+    public ValueTask<Stream?> GetContentAsync(string id)
+    {
+        var file = Path.Combine(baseDir, id + ".md");
+        if (!File.Exists(file))
+            return ValueTask.FromResult(default(Stream));
+
+        return new ValueTask<Stream?>(File.OpenRead(file));
+    }
+
+    public ValueTask<long?> GetTimestampAsync(string id)
+    {
+        var file = Path.Combine(baseDir, id + ".md");
+        if (!File.Exists(file))
+            return ValueTask.FromResult<long?>(null);
+
+        using var stream = File.OpenRead(file);
+        if (ContentInfo.ReadFrontMatter(stream) is { Timestamp: var timestamp })
+            return new ValueTask<long?>(timestamp);
+
+        return ValueTask.FromResult<long?>(null);
+    }
+
+    public ValueTask<ContentAction> SetContentAsync(string id, long timestamp, Stream content)
+    {
+        var file = Path.Combine(baseDir, id + ".md");
+        var action = ContentAction.Created;
+
+        if (File.Exists(file))
+        {
+            using var stream = File.OpenRead(file);
+            if (ContentInfo.ReadFrontMatter(stream) is { Timestamp: var existingTimestamp })
+            {
+                if (existingTimestamp == timestamp)
+                    return new ValueTask<ContentAction>(ContentAction.Skipped);
+            }
+            action = ContentAction.Updated;
+        }
+
+        using var writer = new StreamWriter(file);
+        content.CopyTo(writer.BaseStream);
+        return new ValueTask<ContentAction>(action);
+    }
+}

--- a/src/OpenLaw/IContentInfo.cs
+++ b/src/OpenLaw/IContentInfo.cs
@@ -1,0 +1,7 @@
+﻿namespace Clarius.OpenLaw;
+
+public interface IContentInfo
+{
+    string Id { get; }
+    long Timestamp { get; }
+}

--- a/src/OpenLaw/IContentRepository.cs
+++ b/src/OpenLaw/IContentRepository.cs
@@ -1,0 +1,9 @@
+﻿namespace Clarius.OpenLaw;
+
+public interface IContentRepository
+{
+    IAsyncEnumerable<IContentInfo> EnumerateAsync(CancellationToken cancellation);
+    ValueTask<Stream?> GetContentAsync(string id);
+    ValueTask<long?> GetTimestampAsync(string id);
+    ValueTask<ContentAction> SetContentAsync(string id, long timestamp, Stream content);
+}

--- a/src/OpenLaw/OpenLaw.csproj
+++ b/src/OpenLaw/OpenLaw.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="ThisAssembly.Resources" Version="2.0.12" PrivateAssets="all" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
     <PackageReference Include="Markdown2Pdf" Version="2.2.1" />
+    <PackageReference Include="SharpYaml" Version="2.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenLaw/SyncManager.cs
+++ b/src/OpenLaw/SyncManager.cs
@@ -1,0 +1,36 @@
+﻿using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace Clarius.OpenLaw;
+
+public record struct SyncResult(string Id, ContentAction Action);
+
+/// <summary>
+/// Simple synchronization manager that syncs content from a source to a target repository in 
+/// a single-threaded way.
+/// </summary>
+public class SyncManager(IContentRepository source, IContentRepository target)
+{
+    /// <summary>
+    /// Synchronizes content from the source to the target repository.
+    /// </summary>
+    /// <param name="cancellation">Token to cancel the enumeration.</param>
+    /// <returns>An asynchonous enumeration of the results of each content sync operation.</returns>
+    public async IAsyncEnumerable<SyncResult> Sync([EnumeratorCancellation] CancellationToken cancellation = default)
+    {
+        await foreach (var info in source.EnumerateAsync(cancellation))
+        {
+            var timestamp = await target.GetTimestampAsync(info.Id);
+            if (timestamp != info.Timestamp)
+            {
+                using var content = await source.GetContentAsync(info.Id);
+                Debug.Assert(content is not null);
+                yield return new SyncResult(info.Id, await target.SetContentAsync(info.Id, info.Timestamp, content));
+            }
+            else
+            {
+                yield return new SyncResult(info.Id, ContentAction.Skipped);
+            }
+        }
+    }
+}

--- a/src/Tests/Argentina/SaijClientExtensions.cs
+++ b/src/Tests/Argentina/SaijClientExtensions.cs
@@ -15,7 +15,7 @@ public static class SaijClientExtensions
     {
         await foreach (var doc in client.SearchAsync(tipo, jurisdiccion, provincia, skip, take, cancellation))
         {
-            if (await client.FetchJsonAsync(doc.Uuid) is not { } json)
+            if (await client.FetchJsonAsync(doc.Id) is not { } json)
                 continue;
 
             yield return json;

--- a/src/Tests/Argentina/SaijClientTests.cs
+++ b/src/Tests/Argentina/SaijClientTests.cs
@@ -115,15 +115,15 @@ public class SaijClientTests(ITestOutputHelper output)
         await foreach (var item in client.SearchAsync())
         {
             total++;
-            if (await client.FetchDocumentAsync(item.Uuid) is { } doc &&
+            if (await client.FetchDocumentAsync(item.Id) is { } doc &&
                 doc.Publication is null)
             {
                 nopub++;
-                var json = await client.FetchJsonAsync(item.Uuid);
+                var json = await client.FetchJsonAsync(item.Id);
                 Assert.NotNull(json);
                 var pub = await JQ.ExecuteAsync(json.ToJsonString(options),
                     ".document.content[\"publicacion-codificada\"]");
-                output.WriteLine($"{item.Uuid}: {pub}");
+                output.WriteLine($"{item.Id}: {pub}");
             }
         }
 
@@ -137,13 +137,13 @@ public class SaijClientTests(ITestOutputHelper output)
         var client = CreateClient(output);
         await foreach (var item in client.SearchAsync())
         {
-            if (await client.FetchJsonAsync(item.Uuid) is { } doc)
+            if (await client.FetchJsonAsync(item.Id) is { } doc)
             {
                 var segments = await JQ.ExecuteAsync(
                     doc.ToJsonString(options),
                     ".document.content.articulo | .. | .segmento? | select(. != null)");
 
-                Assert.True(string.IsNullOrEmpty(segments), $"Expected null for document {item.Uuid}");
+                Assert.True(string.IsNullOrEmpty(segments), $"Expected null for document {item.Id}");
             }
         }
     }
@@ -173,7 +173,7 @@ public class SaijClientTests(ITestOutputHelper output)
 
         await foreach (var doc in client.SearchAsync(TipoNorma.Acordada))
         {
-            var json = await client.FetchJsonAsync(doc.Uuid);
+            var json = await client.FetchJsonAsync(doc.Id);
             Assert.NotNull(json);
             output.WriteLine(json.ToJsonString(options));
             count++;
@@ -217,7 +217,7 @@ public class SaijClientTests(ITestOutputHelper output)
         var count = 0;
         await foreach (var doc in client.SearchAsync())
         {
-            var raw = await client.FetchAsync(doc.Uuid);
+            var raw = await client.FetchAsync(doc.Id);
             Assert.NotNull(raw);
             var json = await JQ.ExecuteAsync(raw.Json, ".document.content.d_link // empty");
             if (string.IsNullOrEmpty(json))
@@ -231,7 +231,7 @@ public class SaijClientTests(ITestOutputHelper output)
             }
 
             File.AppendAllText(@$"..\..\..\Argentina\SaijSamples\links.txt",
-                $"{doc.Uuid}: {link.filename} {link.uuid}\n",
+                $"{doc.Id}: {link.filename} {link.uuid}\n",
                 System.Text.Encoding.UTF8);
 
             count++;
@@ -284,7 +284,7 @@ public class SaijClientTests(ITestOutputHelper output)
         {
             Assert.Equal(tipo, doc.Source.Tipo);
             output.WriteLine(doc.ToYaml());
-            await WriteAsync(client, doc.Uuid, $@"..\..\..\Argentina\SaijSamples\{tipo}");
+            await WriteAsync(client, doc.Id, $@"..\..\..\Argentina\SaijSamples\{tipo}");
             return;
         }
 
@@ -301,7 +301,7 @@ public class SaijClientTests(ITestOutputHelper output)
         {
             Assert.Equal(tipo, doc.Source.Tipo);
             output.WriteLine(doc.ToYaml());
-            await WriteAsync(client, doc.Uuid, $@"..\..\..\Argentina\SaijSamples\{tipo}\{provincia}");
+            await WriteAsync(client, doc.Id, $@"..\..\..\Argentina\SaijSamples\{tipo}\{provincia}");
             return;
         }
 

--- a/src/Tests/ContentInfoTests.cs
+++ b/src/Tests/ContentInfoTests.cs
@@ -1,0 +1,29 @@
+﻿using System.Text;
+using SharpYaml.Serialization;
+using Xunit;
+
+namespace Clarius.OpenLaw;
+
+public class ContentInfoTests
+{
+    [Fact]
+    public void WhenReadingEmptyFrontMatter_ThenReturnsNull()
+    {
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes("---\n---"));
+        Assert.Null(ContentInfo.ReadFrontMatter(stream));
+    }
+
+    [Fact]
+    public void WhenReadingFrontMatter_ThenReturnsContentInfo()
+    {
+        var id = Guid.NewGuid().ToString();
+        var timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(new ContentInfo(id, timestamp).ToFrontMatter()));
+
+        var info = ContentInfo.ReadFrontMatter(stream);
+
+        Assert.NotNull(info);
+        Assert.Equal(id, info!.Id);
+        Assert.Equal(timestamp, info.Timestamp);
+    }
+}

--- a/src/Tests/SyncTests.cs
+++ b/src/Tests/SyncTests.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using Clarius.OpenLaw.Argentina;
+using NuGet.Packaging.Signing;
+using NuGet.Versioning;
+using Xunit;
+
+namespace Clarius.OpenLaw;
+
+public class SyncTests : IDisposable
+{
+    string targetDir;
+
+    public SyncTests()
+    {
+        targetDir = Guid.NewGuid().ToString();
+        Directory.CreateDirectory(targetDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(targetDir))
+            Directory.Delete(targetDir, true);
+    }
+
+    [Fact]
+    public async Task CanSyncToTarget()
+    {
+        var source = new TestContentRepository(Enumerable.Range(1, 3));
+        var target = new FileContentRepository(targetDir);
+
+        // 1 won't exist
+        // 2 will be skipped
+        File.WriteAllText(Path.Combine(targetDir, "2.md"), new ContentInfo("2", 2).ToFrontMatter());
+        // 3 will be updated
+        File.WriteAllText(Path.Combine(targetDir, "3.md"), new ContentInfo("3", 0).ToFrontMatter());
+
+        var sync = new SyncManager(source, target);
+
+        await foreach (var result in sync.Sync())
+        {
+            if (result.Id == "1")
+            {
+                Assert.Equal(ContentAction.Created, result.Action);
+            }
+            else if (result.Id == "2")
+            {
+                Assert.Equal(ContentAction.Skipped, result.Action);
+            }
+            else if (result.Id == "3")
+            {
+                Assert.Equal(ContentAction.Updated, result.Action);
+            }
+            else
+            {
+                Assert.Fail("Should have no more items");
+            }
+        }
+    }
+
+    class TestContentRepository(IEnumerable<int> values) : IContentRepository
+    {
+        public async IAsyncEnumerable<IContentInfo> EnumerateAsync([EnumeratorCancellation] CancellationToken cancellation)
+        {
+            foreach (var value in values)
+            {
+                cancellation.ThrowIfCancellationRequested();
+                yield return new ValueContent(value);
+                await Task.Yield();
+            }
+        }
+
+        public ValueTask<Stream?> GetContentAsync(string id) => new ValueTask<Stream?>(new MemoryStream(Encoding.UTF8.GetBytes(id)));
+        public ValueTask<long?> GetTimestampAsync(string id) => new ValueTask<long?>(long.Parse(id));
+        public ValueTask<ContentAction> SetContentAsync(string id, long timestamp, Stream content) => throw new NotImplementedException();
+    }
+
+    class ValueContent(int value) : IContentInfo
+    {
+        string IContentInfo.Id => value.ToString();
+
+        long IContentInfo.Timestamp => value;
+    }
+}

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -7,7 +7,6 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="SharpYaml" Version="2.1.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2" />
     <PackageReference Include="ThisAssembly.Project" Version="2.0.12" PrivateAssets="all" />


### PR DESCRIPTION
This initial cut focuses on getting the API right. We rename back the Uuid > Id since that's more agnostic to specific repositories, and introduce Alias for the SAIJ ID instead. The alias is still used for the web urls, and the ID for data urls.

The sync algorithm enumerates the source repo, gets the timestamp from the target repo, and acts accordingly by creating or updating the content in the target repo if it doesn't exist or doesn't match the source repo timestamp.

For the file repo, we check the timestamp as an optimization nevertheless, in case the caller of the repo API didn't previosly check the timestamp. Originally,we had only this method and no separte GetTimestamp, but since fetching the document content from SAIJ requires another HTTP request, we wanted to avoid it if the target file/timestamp already matched, for performance reasons.