### PR TITLE
Simplify timestamp number format

### DIFF
--- a/src/OpenLaw/Argentina/SaijDocument.jq
+++ b/src/OpenLaw/Argentina/SaijDocument.jq
@@ -2,19 +2,7 @@ def to_timestamp:
   if . == null then null
   elif type == "number" then .
   else
-    # Remove trailing "Z" if present
-    (sub("Z$"; "") | 
-    # Split date and time, ignoring milliseconds
-    split("T") | 
-    (.[0] | split("-") | map(tonumber)) as $date | 
-    (if length > 1 then .[1] | split(":") | map(split(".") | .[0] | tonumber) else [0, 0, 0] end) as $time |
-    # Extract year, month, day, hour, minute, second
-    ($date[0]) as $year | ($date[1]) as $month | ($date[2]) as $day |
-    ($time[0]) as $hour | ($time[1]) as $minute | ($time[2]) as $second |
-    # Calculate days since 0001-01-01 (simplified, no leap year adjustment)
-    (($year - 1) * 365.25 + ($month - 1) * 30.42 + $day) as $total_days |
-    # Convert to seconds
-    ($total_days * 86400 + $hour * 3600 + $minute * 60 + $second | floor))
+    (sub("Z$"; "") | [match("\\d+"; "g").string] | join("") + "00000000000000" | .[0:14] | tonumber)
   end;
 
 .document | {

--- a/src/OpenLaw/Argentina/SearchResult.jq
+++ b/src/OpenLaw/Argentina/SearchResult.jq
@@ -2,22 +2,10 @@
   if . == null then null
   elif type == "number" then .
   else
-    # Remove trailing "Z" if present
-    (sub("Z$"; "") | 
-    # Split date and time, ignoring milliseconds
-    split("T") | 
-    (.[0] | split("-") | map(tonumber)) as $date | 
-    (if length > 1 then .[1] | split(":") | map(split(".") | .[0] | tonumber) else [0, 0, 0] end) as $time |
-    # Extract year, month, day, hour, minute, second
-    ($date[0]) as $year | ($date[1]) as $month | ($date[2]) as $day |
-    ($time[0]) as $hour | ($time[1]) as $minute | ($time[2]) as $second |
-    # Calculate days since 0001-01-01 (simplified, no leap year adjustment)
-    (($year - 1) * 365.25 + ($month - 1) * 30.42 + $day) as $total_days |
-    # Convert to seconds
-    ($total_days * 86400 + $hour * 3600 + $minute * 60 + $second | floor))
+    (sub("Z$"; "") | [match("\\d+"; "g").string] | join("") + "00000000000000" | .[0:14] | tonumber)
   end;
   
-  .document | {
+.document | {
     id: .metadata.uuid,
     contentType: .metadata["document-content-type"], 
     documentType: .content["tipo-norma"] | { code: .codigo, text: .texto },


### PR DESCRIPTION
Rather than an opaque seconds calculation, just use the (already) sortable date-time representation, ensuring it has a time part (padding as necessary), so we get consistent lenghts.