### PR TITLE
Add exponential backoff wait for retries

### DIFF
--- a/src/OpenLaw/Argentina/SyncCommand.cs
+++ b/src/OpenLaw/Argentina/SyncCommand.cs
@@ -129,6 +129,13 @@ public class SyncCommand(IAnsiConsole console, IHttpClientFactory http) : AsyncC
 
                 await Parallel.ForEachAsync(GetResults(), options, async (item, cancellation) =>
                 {
+                    // If item attempts > 2, add an await Task.Delay that is exponential to the attempts. 
+                    if (item.Attempts >= 2)
+                    {
+                        var delay = TimeSpan.FromSeconds(Math.Pow(2, item.Attempts));
+                        await Task.Delay(delay, cancellation);
+                    }
+
                     var action = await item.ExecuteAsync();
                     if (action != null)
                     {

--- a/src/Tests/Argentina/SaijClientTests.cs
+++ b/src/Tests/Argentina/SaijClientTests.cs
@@ -325,6 +325,30 @@ public class SaijClientTests(ITestOutputHelper output)
         Assert.NotNull(doc);
     }
 
+    [Theory]
+    [InlineData(
+        """
+        {
+          "id": "123456789-0abc-442-0000-7102soterced",
+          "contentType": "legislacion",
+          "documentType": {
+            "code": "DEC",
+            "text": "Decreto"
+          },
+          "date": "2017-04-07",
+          "status": "Vigente, de alcance general",
+          "timestamp": null
+        }        
+        """)]
+    public async Task SkipsTrueFailure(string jq)
+    {
+        var client = CreateClient(output);
+        var item = JsonOptions.Default.TryDeserialize<SearchResult>(jq);
+        Assert.NotNull(item);
+        var doc = await client.LoadAsync(item);
+        Assert.NotNull(doc);
+    }
+
     [LocalTheory]
     [MemberData(nameof(LoadErrorData), 10)]
     public async Task CanLoadFormerErrors(string id)


### PR DESCRIPTION
We saw a few errors that even after 5 attempts, ended up being transient (curl succeeds, such as curl https://www.saij.gob.ar/view-document?guid=123456789-0abc-442-0000-7102soterced from https://github.com/clarius/normas/blob/709172b59f2d4c90486e727905ad99c887cb680e/.openlaw/errors/123456789-0abc-442-0000-7102soterced.yml failure)