### PR TITLE
Add conversion from markdown to dictionary

### DIFF
--- a/src/OpenLaw/Argentina/JsonOptions.cs
+++ b/src/OpenLaw/Argentina/JsonOptions.cs
@@ -26,6 +26,7 @@ public static class JsonOptions
     /// </summary>
     public static JsonSerializerOptions Indented { get; } = new(JsonSerializerDefaults.Web)
     {
-        WriteIndented = true
+        WriteIndented = true,
+        Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
     };
 }

--- a/src/Tests/Argentina/SaijClientTests.cs
+++ b/src/Tests/Argentina/SaijClientTests.cs
@@ -325,6 +325,24 @@ public class SaijClientTests(ITestOutputHelper output)
         Assert.NotNull(doc);
     }
 
+    // Ley Bases
+    [Theory]
+    [InlineData("123456789-0abc-defg-g28-67000scanyel")]
+    public async Task CanConvertFromMarkdown(string id)
+    {
+        var client = CreateClient(output);
+        var doc = await client.LoadAsync(id);
+        var markdown = doc.ToMarkdown(true);
+
+        var data = DictionaryConverter.FromMarkdown(markdown);
+
+        Assert.NotNull(data);
+        Assert.Contains("Id", data.Keys);
+        Assert.Contains("Timestamp", data.Keys);
+        Assert.Contains("WebUrl", data.Keys);
+        Assert.Contains("DataUrl", data.Keys);
+    }
+
     [Theory]
     [InlineData(
         """


### PR DESCRIPTION
This allows retrieving the data portions of the YAML in a markdown doc we emit.