### PR TITLE
Add support for reading the normative references

### DIFF
--- a/src/OpenLaw/Argentina/Document.cs
+++ b/src/OpenLaw/Argentina/Document.cs
@@ -11,31 +11,32 @@ public record Document(
     string Status, DateOnly Date,
     string Modified, long Timestamp,
     string[] Terms,
-    [property: JsonPropertyName("pub")] Publication? Publication) : IContentInfo, IWebDocument, ISearchDocument
+    [property: JsonPropertyName("pub")] Publication? Publication,
+    [property: JsonPropertyName("refs")] References? References) : IContentInfo, IWebDocument, ISearchDocument
 {
     readonly NormalizedWebDocument normalizer = new(Id);
 
     public string WebUrl => $"https://www.saij.gob.ar/{Alias}";
     public string DataUrl => $"https://www.saij.gob.ar/view-document?guid={Id}";
 
-    [YamlIgnore, SharpYaml.Serialization.YamlIgnore, JsonIgnore]
+    [YamlIgnore, JsonIgnore]
     public string Json
     {
         get => normalizer.Json;
         init => normalizer = normalizer with { Json = value };
     }
 
-    [YamlIgnore, SharpYaml.Serialization.YamlIgnore, JsonIgnore]
+    [YamlIgnore, JsonIgnore]
     public string JQ
     {
         get => normalizer.JQ;
         init => normalizer = normalizer with { JQ = value };
     }
 
-    [YamlIgnore, SharpYaml.Serialization.YamlIgnore, JsonIgnore]
+    [YamlIgnore, JsonIgnore]
     public Dictionary<string, object?> Data => normalizer.Data;
 
-    [YamlIgnore, SharpYaml.Serialization.YamlIgnore, JsonIgnore]
+    [YamlIgnore, JsonIgnore]
     public Search Query { get; init; } = Search.Empty;
 
     long? IContentInfo.Timestamp => Timestamp;

--- a/src/OpenLaw/Argentina/References.cs
+++ b/src/OpenLaw/Argentina/References.cs
@@ -1,0 +1,30 @@
+﻿using System.Text.Json.Serialization;
+using YamlDotNet.Serialization;
+
+namespace Clarius.OpenLaw.Argentina;
+
+/// <summary>
+/// Tracks references of different kinds from and to other documents.
+/// </summary>
+public record References(Reference Ammends, Reference Repeals, Reference Remarks);
+
+/// <summary>
+/// Links documents via references.
+/// </summary>
+/// <param name="By">Incoming references from other documents.</param>
+/// <param name="To">Outgoing references to other documents.</param>
+public record Reference(
+    [property: YamlIgnore] HashSet<string> By,
+    [property: YamlIgnore] HashSet<string> To)
+{
+    // NOTE: when deserializing from JSON, we'll get the full By/To list.
+    // When serializing to YAML, though, we only care about the count (for now).
+    // This keeps the markdown docs small. If we need the full data, we'd need 
+    // to fetch the original JSON anyway (i.e. which articles in particular are 
+    // referenced and so on).
+    [YamlMember(Alias = nameof(By)), JsonIgnore]
+    public int ByCount => By.Count;
+
+    [YamlMember(Alias = nameof(To)), JsonIgnore]
+    public int ToCount => To.Count;
+}

--- a/src/OpenLaw/Argentina/SaijClient.cs
+++ b/src/OpenLaw/Argentina/SaijClient.cs
@@ -187,6 +187,7 @@ public class SaijClient(IHttpClientFactory httpFactory, IProgress<ProgressMessag
         if (!DisplayValue.TryParse<ContentType>(idType.Type, true, out _))
             throw new NotSupportedException($"Unsupported document content type '{idType.Type}' with ID '{id}'.");
 
+
         if (await JQ.ExecuteAsync(data, ThisAssembly.Resources.Argentina.SaijDocument.Text) is not { } docjq ||
             JsonOptions.Default.TryDeserialize<Document>(docjq) is not { } doc)
             throw new NotSupportedException($"Invalid document data for ID '{id}'.");

--- a/src/OpenLaw/Argentina/SaijDocument.jq
+++ b/src/OpenLaw/Argentina/SaijDocument.jq
@@ -5,6 +5,29 @@ def to_timestamp:
     (sub("Z$"; "") | [match("\\d+"; "g").string] | join("") + "00000000000000" | .[0:14] | tonumber)
   end;
 
+def articulos($node):
+  if $node | type == "object" then
+    if $node | has("articulo") then
+      if $node.articulo | type == "array" then $node.articulo[] else $node.articulo end
+    else
+      empty
+    end,
+    if $node | has("segmento") then $node.segmento[] | articulos(.) else empty end
+  elif $node | type == "array" then
+    $node[] | articulos(.)
+  else
+    empty
+  end;
+
+# Extract references from a given field name, handling both object and array structures
+def refs($context; $name):
+  [ articulos($context),
+    (if ($context.anexo | type) == "array" then $context.anexo[] else empty end)
+  ] | flatten |
+  map(.[$name]? | select(. != null) | .["referencia-normativa"]? |
+      (if type == "array" then .[] | .ref else .ref end)) |
+  flatten | select(. != null);
+
 .document | {
     id: .metadata.uuid,
     type: .metadata["document-content-type"], 
@@ -41,5 +64,19 @@ def to_timestamp:
         .content.descriptores?.descriptor?.sinonimos?.termino[]?, 
         .content.descriptores?.suggest?.termino[]?)
     ] | map(select(. != null)) | flatten | unique | map(gsub("^\\s+|\\s+$"; "")),
-    pub: first((.content["publicacion-codificada"] | .. | select(.organismo? != null) | { org: .organismo, date: (.fecha // .["fecha-sf"]) | gsub(" "; "-")}) // null)
+    pub: first((.content["publicacion-codificada"] | .. | select(.organismo? != null) | { org: .organismo, date: (.fecha // .["fecha-sf"]) | gsub(" "; "-")}) // null),
+    refs: {
+        ammends: {
+            by: refs(.content; "modificado-por") | unique | sort,
+            to: refs(.content; "modifica-a") | unique | sort
+        }, 
+        repeals: {
+            by: refs(.content; "derogado-por") | unique | sort,
+            to: refs(.content; "deroga-a") | unique | sort
+        }, 
+        remarks: {
+            by: refs(.content; "observado-por") | unique | sort,
+            to: refs(.content; "observa-a") | unique | sort
+        }
+    }
 }

--- a/src/OpenLaw/ContentInfo.cs
+++ b/src/OpenLaw/ContentInfo.cs
@@ -1,11 +1,14 @@
 ﻿using System.Text;
-using SharpYaml.Serialization;
+using Clarius.OpenLaw.Argentina;
+using YamlDotNet.Serialization;
 
 namespace Clarius.OpenLaw;
 
 public class ContentInfo(string id, long timestamp) : IContentInfo
 {
-    static readonly Serializer serializer = new(new() { IgnoreUnmatchedProperties = true });
+    static readonly IDeserializer serializer = new DeserializerBuilder()
+        .IgnoreUnmatchedProperties()
+        .Build();
 
     public string Id { get; init; } = id;
     public long Timestamp { get; init; } = timestamp;
@@ -41,7 +44,7 @@ public class ContentInfo(string id, long timestamp) : IContentInfo
 
     public string ToFrontMatter(FrontMatter style = FrontMatter.Markdown)
     {
-        var yaml = serializer.Serialize(this);
+        var yaml = this.ToYaml();
 
         return style switch
         {

--- a/src/OpenLaw/OpenLaw.csproj
+++ b/src/OpenLaw/OpenLaw.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="ThisAssembly.Resources" Version="2.0.12" PrivateAssets="all" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
     <PackageReference Include="Markdown2Pdf" Version="2.2.1" />
-    <PackageReference Include="SharpYaml" Version="2.1.1" />
+    <!--<PackageReference Include="SharpYaml" Version="2.1.1" />-->
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tests/ContentInfoTests.cs
+++ b/src/Tests/ContentInfoTests.cs
@@ -1,5 +1,4 @@
 ﻿using System.Text;
-using SharpYaml.Serialization;
 using Xunit;
 
 namespace Clarius.OpenLaw;


### PR DESCRIPTION
For now, we just collect the references as belonging to the doc as a whole. When serializing as YAML front-matter, we only persist the count of linked norms, to keep the markdown small. The full data about normative references would still require full data fetch in JSON format and further analysis anyway, since the references apply to specific sections of a norm.

We took the chance to remove SharpYaml and avoid confusion about which lib we're using (for now?) for our YAML needs.