### PR TITLE
Add doc id to front-matter

### DIFF
--- a/src/OpenLaw/Argentina/DocumentExtensions.cs
+++ b/src/OpenLaw/Argentina/DocumentExtensions.cs
@@ -8,7 +8,8 @@ public static class DocumentExtensions
     record FrontMatter(
         [property: YamlMember(Alias = "Fecha")] string Date,
         [property: YamlMember(Alias = "Título")] string Name,
-        [property: JsonPropertyName("pub"), YamlMember(Alias = "Publicación")] Publication? Publication)
+        [property: JsonPropertyName("pub"), YamlMember(Alias = "Publicación")] Publication? Publication,
+        [property: YamlMember(Order = int.MaxValue)] string Id)
     {
         [YamlMember(Alias = "SAIJ")]
         public string? WebUrl { get; set; }

--- a/src/Tests/Argentina/YamlTests.cs
+++ b/src/Tests/Argentina/YamlTests.cs
@@ -60,6 +60,7 @@ public class YamlTests(ITestOutputHelper output)
               Organismo: Boletín Oficial
               Fecha: 2024-12-27
             SAIJ: https://www.saij.gob.ar/123456789-0abc-104-0000-4202xvorpced
+            Id: 123456789-0abc-104-0000-4202xvorpced
             """, yaml);
     }
 


### PR DESCRIPTION
This would make it possible to lookup the full metadata json document from the markdown too.