### PR TITLE
Add advanced filter support, make active docs a filter

### DIFF
--- a/src/OpenLaw/Argentina/EnumerateCommand.cs
+++ b/src/OpenLaw/Argentina/EnumerateCommand.cs
@@ -53,7 +53,7 @@ public class EnumerateCommand(IAnsiConsole console, IHttpClientFactory http) : A
                         while (true)
                         {
                             // Fetch a batch
-                            var search = client.SearchAsync(settings.Tipo, settings.Jurisdiccion, settings.Provincia, skip, take, cancellationToken);
+                            var search = client.SearchAsync(settings.Tipo, settings.Jurisdiccion, settings.Provincia, settings.Filters, skip, take, cancellationToken);
                             var count = 0;
                             await foreach (var item in search)
                             {

--- a/src/OpenLaw/Argentina/KnownFilters.cs
+++ b/src/OpenLaw/Argentina/KnownFilters.cs
@@ -1,0 +1,16 @@
+﻿namespace Clarius.OpenLaw.Argentina;
+
+public static class KnownFilters
+{
+    public static IDictionary<string, string> AddFilter(this IDictionary<string, string> filters, string filter)
+    {
+        var parts = filter.Split('/');
+        filters[parts[0]] = parts[1];
+        return filters;
+    }
+
+    public static class EstadoDeVigencia
+    {
+        public const string VigenteDeAlcanceGeneral = "Estado de Vigencia/Vigente, de alcance general";
+    }
+}

--- a/src/OpenLaw/Argentina/SaijSettings.cs
+++ b/src/OpenLaw/Argentina/SaijSettings.cs
@@ -6,22 +6,30 @@ namespace Clarius.OpenLaw.Argentina;
 
 public class ClientSettings : CommandSettings
 {
-    [Description("Tipo de norma a sincronizar.")]
+    [Description("Tipo de norma a sincronizar")]
     [CommandOption("-t|--tipo")]
     [DefaultValue(TipoNorma.Ley)]
     public TipoNorma? Tipo { get; set; } = TipoNorma.Ley;
 
-    [Description("Jurisdicción a sincronizar.")]
+    [Description("Jurisdicción a sincronizar")]
     [CommandOption("-j|--jurisdiccion")]
     [DefaultValue(Argentina.Jurisdiccion.Nacional)]
     public Jurisdiccion? Jurisdiccion { get; set; } = Argentina.Jurisdiccion.Nacional;
 
-    [Description("Provincia a sincronizar.")]
+    [Description("Provincia a sincronizar")]
     [CommandOption("-p|--provincia")]
     [DefaultValue(null)]
     public Provincia? Provincia { get; set; }
 
-    [Description("Enumerar todo, sin filtros.")]
+    [Description("Filtros avanzados a aplicar (KEY=VALUE)")]
+    [CommandOption("-f|--filtro")]
+    public Dictionary<string, string> Filters { get; set; } = [];
+
+    [Description("Mostrar solo leyes/decretos vigentes")]
+    [CommandOption("--vigentes")]
+    public bool Vigentes { get; set; }
+
+    [Description("Enumerar todo, sin filtros")]
     [CommandOption("--all", IsHidden = true)]
     public bool All { get; set; }
 
@@ -39,6 +47,9 @@ public class ClientSettings : CommandSettings
 
         if (Jurisdiccion != Argentina.Jurisdiccion.Provincial && Provincia != null)
             return ValidationResult.Error("No se puede especificar una provincia para la jurisdicción no provincial.");
+
+        if (Vigentes)
+            Filters.AddFilter(KnownFilters.EstadoDeVigencia.VigenteDeAlcanceGeneral);
 
         return base.Validate();
     }

--- a/src/OpenLaw/Argentina/SyncCommand.cs
+++ b/src/OpenLaw/Argentina/SyncCommand.cs
@@ -55,7 +55,7 @@ public class SyncCommand(IAnsiConsole console, IHttpClientFactory http) : AsyncC
                         while (true)
                         {
                             // Fetch a batch
-                            var search = client.SearchAsync(settings.Tipo, settings.Jurisdiccion, settings.Provincia, skip, PageSize, cancellationToken);
+                            var search = client.SearchAsync(settings.Tipo, settings.Jurisdiccion, settings.Provincia, settings.Filters, skip, PageSize, cancellationToken);
                             var count = 0;
                             await foreach (var item in search)
                             {

--- a/src/dotnet-openlaw/sync.md
+++ b/src/dotnet-openlaw/sync.md
@@ -11,6 +11,8 @@ OPTIONS:
     -t, --tipo            Ley         Tipo de norma a sincronizar               
     -j, --jurisdiccion    Nacional    Jurisdicción a sincronizar                
     -p, --provincia                   Provincia a sincronizar                   
+    -f, --filtro                      Filtros avanzados a aplicar (KEY=VALUE)   
+        --vigentes                    Mostrar solo leyes/decretos vigentes      
         --dir                         Ubicación opcional archivos. Por defecto  
                                       el directorio actual                      
         --changelog                   Escribir un resumen de las operaciones    


### PR DESCRIPTION
Rather than hardcoding the search to always filter by active norms, let the client drive that via a CLI setting. This makes the app more flexible should we want to sync other norm types that supports their own filters (like jury, admin branch, etc.).