### PR TITLE
Change error persistence to subfolder of .github

### DIFF
--- a/src/OpenLaw/Argentina/SyncCommand.cs
+++ b/src/OpenLaw/Argentina/SyncCommand.cs
@@ -147,8 +147,9 @@ public class SyncCommand(IAnsiConsole console, IHttpClientFactory http) : AsyncC
 
         if (poison.Count > 0)
         {
-            var errorsDir = Directory.CreateDirectory(".openlaw/errors").FullName;
-            console.MarkupLine($":cross_mark: [red]{poison.Count}[/] fallas de sincronización en [link={errorsDir}].openlaw/errors[/].");
+            var errorsDir = Path.Combine(".github", ".openlaw", settings.Directory);
+            Directory.CreateDirectory(errorsDir);
+            console.MarkupLine($":cross_mark: [red]{poison.Count}[/] fallas de sincronización en [link={errorsDir}]{errorsDir}[/].");
             foreach (var error in poison)
             {
                 await File.WriteAllTextAsync(Path.Combine(errorsDir, $"{error.Item.Id}.yml"),


### PR DESCRIPTION
Preseving the target folder structure to simplify the retry sync later