### PR TITLE
Downgrade main lib to .NET8 for usage in Azure Functions

### DIFF
--- a/src/OpenLaw/Argentina/DictionaryConverter.cs
+++ b/src/OpenLaw/Argentina/DictionaryConverter.cs
@@ -7,7 +7,11 @@ namespace Clarius.OpenLaw.Argentina;
 
 public static partial class DictionaryConverter
 {
+#if NET9_0_OR_GREATER
     static readonly Lock sync = new();
+#else
+    static readonly object sync = new();
+#endif
 
     static readonly JsonSerializerOptions options = new()
     {

--- a/src/OpenLaw/OpenLaw.csproj
+++ b/src/OpenLaw/OpenLaw.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <EmbeddedResourceStringExtensions>.jq;$(EmbeddedResourceStringExtensions)</EmbeddedResourceStringExtensions>
     <PackageId>Clarius.OpenLaw</PackageId>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
@@ -12,13 +12,13 @@
     <PackageReference Include="Devlooped.JQ" Version="1.7.1.3" />
     <PackageReference Include="DotNetConfig.Configuration" Version="1.2.0" />
     <PackageReference Include="Humanizer.Core.es" Version="2.14.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.3.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageReference Include="Devlooped.Web" Version="1.3.0" />
     <PackageReference Include="NuGet.Protocol" Version="6.13.2" />
     <PackageReference Include="NuGetizer" Version="1.2.4" PrivateAssets="all" />

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -12,6 +12,9 @@
     <PackageReference Include="ThisAssembly.Project" Version="2.0.12" PrivateAssets="all" />
     <PackageReference Include="Markdown2Pdf" Version="2.2.1" />
     <PackageReference Include="ThisAssembly.AssemblyInfo" Version="2.0.12" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/dotnet-openlaw/dotnet-openlaw.csproj
+++ b/src/dotnet-openlaw/dotnet-openlaw.csproj
@@ -16,6 +16,9 @@
     <PackageReference Include="Spectre.Console.Cli" Version="0.49.1" />
     <PackageReference Include="ThisAssembly.Git" Version="2.0.12" PrivateAssets="all" />
     <PackageReference Include="ThisAssembly.Project" Version="2.0.12" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This is required by downstream consumption to make it more broadly usable.