### PR TITLE
Add sync details to markdown report

### DIFF
--- a/src/OpenLaw/Argentina/SyncActionResult.cs
+++ b/src/OpenLaw/Argentina/SyncActionResult.cs
@@ -1,0 +1,3 @@
+﻿namespace Clarius.OpenLaw.Argentina;
+
+public record SyncActionResult(ContentAction Action, Document NewDocument, Document? OldDocument);

--- a/src/OpenLaw/Argentina/SyncSummary.cs
+++ b/src/OpenLaw/Argentina/SyncSummary.cs
@@ -1,9 +1,12 @@
 ﻿using System.Diagnostics;
+using System.Text;
+using DiffPlex.DiffBuilder;
 
 namespace Clarius.OpenLaw.Argentina;
 
 public class SyncSummary(string operation)
 {
+    readonly List<SyncActionResult> results = [];
     readonly HashSet<string> errors = [];
     readonly Stopwatch stopwatch = Stopwatch.StartNew();
     int created = 0;
@@ -19,11 +22,11 @@ public class SyncSummary(string operation)
 
     public TimeSpan Elapsed => stopwatch.Elapsed;
 
-    public static SyncSummary Start(string operation) => new SyncSummary(operation);
+    public static SyncSummary Start(string operation) => new(operation);
 
-    public void Add(ContentAction action)
+    public void Add(SyncActionResult result)
     {
-        switch (action)
+        switch (result.Action)
         {
             case ContentAction.Created:
                 Interlocked.Increment(ref created);
@@ -35,6 +38,8 @@ public class SyncSummary(string operation)
                 Interlocked.Increment(ref skipped);
                 break;
         }
+
+        results.Add(result);
     }
 
     public void Add(Exception? exception)
@@ -56,6 +61,58 @@ public class SyncSummary(string operation)
         if (Skipped > 0) report += $":white_check_mark: {Skipped} ";
         if (Failed > 0) report += $":x: {Failed} ";
 
-        return report + $":hourglass: {Elapsed.ToMinimalString()}";
+        report += $":hourglass: {Elapsed.ToMinimalString()}";
+
+        var details = new StringBuilder();
+
+        // TODO: add/count diff.
+        foreach (var result in results)
+        {
+            // quickly skip from report the dummy updates
+            if (result.Action == ContentAction.Skipped)
+                continue;
+            if (result.Action == ContentAction.Updated &&
+                result.OldDocument != null)
+            {
+                var diff = InlineDiffBuilder.Diff(result.OldDocument!.Json, result.NewDocument.Json)
+                    .Lines.Where(x => x.Type != DiffPlex.DiffBuilder.Model.ChangeType.Unchanged)
+                    .ToList();
+
+                if (diff.Count == 4 &&
+                    diff[0].Type == DiffPlex.DiffBuilder.Model.ChangeType.Deleted && diff[0].Text.Trim().StartsWith("\"timestamp\":") &&
+                    diff[1].Type == DiffPlex.DiffBuilder.Model.ChangeType.Inserted && diff[1].Text.Trim().StartsWith("\"timestamp\":") &&
+                    diff[2].Type == DiffPlex.DiffBuilder.Model.ChangeType.Deleted && diff[2].Text.Trim().StartsWith("\"fecha-umod\":") &&
+                    diff[3].Type == DiffPlex.DiffBuilder.Model.ChangeType.Inserted && diff[3].Text.Trim().StartsWith("\"fecha-umod\":"))
+                {
+                    // discard changes that are only timestamp/fecha-umod
+                    // see: https://github.com/clarius/normas/pull/32/files#diff-2f592ca38476012d2be4d6b3f17789b83b8bd3c3fa1df6eda2e54b8ccc7e1cbc
+                    continue;
+                }
+            }
+
+            details.AppendLine($"{(result.Action == ContentAction.Created ? ":heavy_plus_sign:" : ":pencil:")} {result.NewDocument.Name}: {result.NewDocument.Title}");
+        }
+
+        if (details.Length > 0)
+        {
+            report +=
+                """
+
+
+                <details>
+
+                <summary>:eyes: Detalles</summary>
+
+                """;
+            report += details.ToString();
+            report +=
+                """
+
+
+                </details>
+                """;
+        }
+
+        return report;
     }
 }

--- a/src/OpenLaw/OpenLaw.csproj
+++ b/src/OpenLaw/OpenLaw.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Devlooped.JQ" Version="1.7.1.3" />
     <PackageReference Include="DotNetConfig.Configuration" Version="1.2.0" />
+    <PackageReference Include="DiffPlex" Version="1.7.2" />
     <PackageReference Include="Humanizer.Core.es" Version="2.14.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />

--- a/src/Tests/Argentina/SaijSamples/Diff/123456789-0abc-095-0000-7991soterced-new.json
+++ b/src/Tests/Argentina/SaijSamples/Diff/123456789-0abc-095-0000-7991soterced-new.json
@@ -1,0 +1,381 @@
+{
+  "document": {
+    "metadata": {
+      "uuid": "123456789-0abc-095-0000-7991soterced",
+      "document-content-type": "legislacion",
+      "timestamp": 1743007572027,
+      "operation": "ADD",
+      "target-document-repository-id": "infojus",
+      "target-index-id": "index",
+      "target-document-indexing-id": "legislacion",
+      "document-recovery-strategy": "abstract-legislacion",
+      "friendly-url": {
+        "subdomain": "decreto",
+        "description": "590-nacional-creacion-fondo-para-fines-especificos-marco-ley-riesgos-trabajo-dn19970000590-1997-06-30"
+      }
+    },
+    "content": {
+      "mecanografico": 19970000590,
+      "estado": "Vigente, de alcance general",
+      "tipo-norma": {
+        "codigo": "DEC",
+        "texto": "Decreto"
+      },
+      "numero-norma": 590,
+      "fecha": "1997-06-30",
+      "jurisdiccion": {
+        "codigo": "C",
+        "descripcion": "Nacional",
+        "capital": "Capital Federal",
+        "id-pais": 11
+      },
+      "standard-normativo": "DEC C 000590 1997 06 30",
+      "titulo-norma": "Creación del Fondo para Fines Específicos en el Marco de la Ley de Riesgos del Trabajo",
+      "nombre-coloquial": "DECRETO NACIONAL 590/1997",
+      "lugar-emision": "BUENOS AIRES",
+      "publicacion-codificada": {
+        "publicacion-decodificada": {
+          "organismo": "Boletín Oficial",
+          "fecha": "1997 07 04"
+        }
+      },
+      "analista": "Quintana, Carolina",
+      "responsable": "Quintana, Carolina",
+      "uid-alta": "ABM",
+      "uid-mod": "ABM",
+      "fecha-alta": "2025-03-26",
+      "fecha-mod": "2025-03-26",
+      "timestamp": "2025-03-26T13:39:25",
+      "timestamp-alta": "2025-03-26T13:39:25",
+      "timestamp-m": "2025-03-26T13:39:25",
+      "generalidades": {
+        "sintesis": "SE ESTABLECE, EN EL MARCO DE LA LEY DE RIESGOS DEL TRABAJO, LA CREACION DE UN FONDO PROVISIONAL QUE SE DENOMINARA \"FONDO PARA FINES ESPECIFICOS\".",
+        "observaciones-generales": "CANTIDAD DE ARTICULOS QUE COMPONEN LA NORMA: 10.\n\nOBSERVACION: POR DISPOSICION 2/2021 DE LA SUPERINTENDENCIA DE RIESGOS DEL TRABAJO GERENCIA DE CONTROL PRESTACIONAL (B.O. 27/10/2021) SE ESTABLECE QUE EL VALOR DE LA SUMA FIJA PREVISTA EN EL ART. 5 DEL PRESENTE DECRETO SERA DE ($ 49,98) PARA EL MES DE OCTUBRE Y SE ABONARA A PARTIR DE NOVIEMBRE DE 2021.\n\nOBSERVACION: POR RESOLUCION 794/2021 DEL MINISTERIO DE TRABAJO, EMPLEO Y SEGURIDAD SOCIAL(B.O. 7/12/2021) SE ESTABLECE QUE EL VALOR DE LA SUMA FIJA PREVISTA EN EL ART. 5 DEL PRESENTE DECRETO SERA DE ($100,00) A PARTIR DEL MES DE FEBRERO 2022 SOBRE LOS HABERES DEVENGADOS EN EL MES DE ENERO DE 2022 .\n\nOBSERVACION: POR DISPOSICION 2/2022 DE LA SUPERINTENDENCIA DE RIESGOS DEL TRABAJO GERENCIA DE CONTROL PRESTACIONAL (B.O. 28/04/2022) SE ESTABLECE QUE EL VALOR DE LA SUMA FIJA PREVISTA EN EL ART. 5 DEL PRESENTE DECRETO SERA DE ($111,75) PARA EL DEVENGADO MES DE ABRIL DE 2022 .\n\nOBSERVACION: POR DISPOSICION 3/2022 DE LA SUPERINTENDENCIA DE RIESGOS DEL TRABAJO GERENCIA DE CONTROL PRESTACIONAL (B.O. 19/07/2022) SE ESTABLECE QUE EL VALOR DE LA SUMA FIJA PREVISTA EN EL ART. 5 DEL PRESENTE DECRETO SERA DE ($133) PARA EL DEVENGADO MES DE JULIO DE 2022 .\n\nOBSERVACION: POR RESOLUCION CONJUNTA 1/22 DE LA SUPERINTENDENCIA DE SERVICIOS DE SALUD Y SUPERINTENDENCIA DE SEGUROS DE LA NACIÓN Y SUPERINTENDENCIA DE RIESGOS DEL TRABAJO (B.O. 10/8/2022) SE APRUEBA EL RÉGIMEN EXTRAORDINARIO DE PAGOS DE EROGACIONES EFECTUADAS POR LAS OBRAS SOCIALES A CUENTA DE LOS FONDOS PROVENIENTES DEL FONDO FIDUCIARIO DE ENFERMEDADES PROFESIONALES -CREADO POR EL PRESENTE DECRETO - PARA AFRONTAR LOS COSTOS DE LAS PRESTACIONES MÉDICO ASISTENCIALES VINCULADAS CON LA ENFERMEDAD PRODUCIDA POR EL CORONAVIRUS SARS-CoV-2.\n\nOBSERVACION: POR DISPOSICION 6/2022 DE LA SUPERINTENDENCIA DE RIESGOS DEL TRABAJO GERENCIA DE CONTROL PRESTACIONAL (B.O. 27/10/2022) SE ESTABLECE QUE EL VALOR DE LA SUMA FIJA PREVISTA EN EL ART. 5 DEL PRESENTE DECRETO SERA DE ($155) PARA EL DEVENGADO MES DE OCTUBRE DE 2022 .\n\nOBSERVACION: POR DISPOSICION 7/2022 DE LA SUPERINTENDENCIA DE RIESGOS DEL TRABAJO GERENCIA DE CONTROL PRESTACIONAL (B.O. 24/11/2022) SE ESTABLECE QUE EL VALOR DE LA SUMA FIJA PREVISTA EN EL ART. 5 DEL PRESENTE DECRETO SERA DE ($164) PARA EL DEVENGADO MES DE NOVIEMBRE DE 2022 .\n\nOBSERVACION: POR DISPOSICION 7/2023 DE LA SUPERINTENDENCIA DE RIESGOS DEL TRABAJO GERENCIA DE CONTROL PRESTACIONAL (B.O. 24/7/2023) SE ESTABLECE QUE EL VALOR DE LA SUMA FIJA PREVISTA EN EL ART. 5 DEL PRESENTE DECRETO SERA DE ($278) PARA EL DEVENGADO MES DE JULIO DE 2023 .\n\nOBSERVACION: POR DISPOSICION 9/2023 DE LA SUPERINTENDENCIA DE RIESGOS DEL TRABAJO GERENCIA DE CONTROL PRESTACIONAL (B.O. 20/9/2023) SE ESTABLECE QUE EL VALOR DE LA SUMA FIJA PREVISTA EN EL ART. 5 DEL PRESENTE DECRETO SERA DE ($323) PARA EL DEVENGADO MES DE SEPTIEMBRE DE 2023 .\n\nOBSERVACION: POR DISPOSICION 10/2023 DE LA SUPERINTENDENCIA DE RIESGOS DEL TRABAJO GERENCIA DE CONTROL PRESTACIONAL (B.O. 17/10/2023) SE ESTABLECE QUE EL VALOR DE LA SUMA FIJA PREVISTA EN EL ART. 5 DEL PRESENTE DECRETO SERA DE ($342) PARA EL DEVENGADO MES DE OCTUBRE DE 2023 .\n\nOBSERVACION: POR DISPOSICION 11/2023 DE LA SUPERINTENDENCIA DE RIESGOS DEL TRABAJO GERENCIA DE CONTROL PRESTACIONAL (B.O. 17/11/2023) SE ESTABLECE QUE EL VALOR DE LA SUMA FIJA PREVISTA EN EL ART. 5 DEL PRESENTE DECRETO SERA DE ($374) PARA EL DEVENGADO MES DE NOVIEMBRE DE 2023 .\n\nOBSERVACION: POR DISPOSICION 1/2024 DE LA SUPERINTENDENCIA DE RIESGOS DEL TRABAJO GERENCIA DE CONTROL PRESTACIONAL (B.O. 18/1/2024) SE ESTABLECE QUE EL VALOR DE LA SUMA FIJA PREVISTA EN EL ART. 5 DEL PRESENTE DECRETO SERA DE ($444) PARA EL DEVENGADO MES DE ENERO DE 2024 .\n\nOBSERVACION: POR DISPOSICION 5/2024 DE LA SUPERINTENDENCIA DE RIESGOS DEL TRABAJO GERENCIA DE CONTROL PRESTACIONAL (B.O. 20/5/2024) SE ESTABLECE QUE EL VALOR DE LA SUMA FIJA PREVISTA EN EL ART. 5 DEL PRESENTE DECRETO SERA DE ($ 702) PARA EL DEVENGADO MES DE MAYO 2024 .\n\nOBSERVACION: POR DISPOSICION 6/2024 DE LA SUPERINTENDENCIA DE RIESGOS DEL TRABAJO GERENCIA DE CONTROL PRESTACIONAL (B.O. 26/6/2024) SE ESTABLECE QUE EL VALOR DE LA SUMA FIJA PREVISTA EN EL ART. 5 DEL PRESENTE DECRETO SERA DE ($ 815) PARA EL DEVENGADO MES DE JUNIO DE 2024 .\n\nOBSERVACION: POR DISPOSICION 7/2024 DE LA SUPERINTENDENCIA DE RIESGOS DEL TRABAJO GERENCIA DE CONTROL PRESTACIONAL (B.O. 29/7/2024) SE ESTABLECE QUE EL VALOR DE LA SUMA FIJA PREVISTA EN EL ART. 5 DEL PRESENTE DECRETO SERA DE ($874) PARA EL DEVENGADO MES DE JULIO DE 2024 .\n\nOBSERVACION: POR DISPOSICION 8/2024 DE LA SUPERINTENDENCIA DE RIESGOS DEL TRABAJO GERENCIA DE CONTROL PRESTACIONAL (B.O. 22/8/2024) SE ESTABLECE QUE EL VALOR DE LA SUMA FIJA PREVISTA EN EL ART. 5 DEL PRESENTE DECRETO SERA DE ($928) PARA EL DEVENGADO MES DE AGOSTO DE 2024 .\n\nOBSERVACION: POR DISPOSICION 9/2024 DE LA SUPERINTENDENCIA DE RIESGOS DEL TRABAJO GERENCIA DE CONTROL PRESTACIONAL (B.O. 27/9/2024) SE ESTABLECE QUE EL VALOR DE LA SUMA FIJA PREVISTA EN EL ART. 5 DEL PRESENTE DECRETO SERA DE ($989) PARA EL DEVENGADO MES DE SEPTIEMBRE DE 2024 .\n\nOBSERVACION: POR DISPOSICION 10/2024 DE LA SUPERINTENDENCIA DE RIESGOS DEL TRABAJO GERENCIA DE CONTROL PRESTACIONAL (B.O. 25/10/2024) SE ESTABLECE QUE EL VALOR DE LA SUMA FIJA PREVISTA EN EL ART. 5 DEL PRESENTE DECRETO SERA DE ($1.026) PARA EL DEVENGADO MES DE OCTUBRE DE 2024 .\n\nOBSERVACION: POR DISPOSICION 11/2024 DE LA SUPERINTENDENCIA DE RIESGOS DEL TRABAJO GERENCIA DE CONTROL PRESTACIONAL (B.O. 25/11/2024) SE ESTABLECE QUE EL VALOR DE LA SUMA FIJA PREVISTA EN EL ART. 5 DEL PRESENTE DECRETO SERA DE ($1.069) PARA EL DEVENGADO MES DE NOVIEMBRE DE 2024 .\n\nOBSERVACION: POR DISPOSICION 12/2024 DE LA SUPERINTENDENCIA DE RIESGOS DEL TRABAJO GERENCIA DE CONTROL PRESTACIONAL (B.O. 26/12/2024) SE ESTABLECE QUE EL VALOR DE LA SUMA FIJA PREVISTA EN EL ART. 5 DEL PRESENTE DECRETO SERA DE ($1.140) PARA EL DEVENGADO MES DE DICIEMBRE DE 2024 .\n\nOBSERVACION: POR DISPOSICION 1/2025 DE LA SUPERINTENDENCIA DE RIESGOS DEL TRABAJO GERENCIA DE CONTROL PRESTACIONAL (B.O. 17/01/2025) SE ESTABLECE QUE EL VALOR DE LA SUMA FIJA PREVISTA EN EL ART. 5 DEL PRESENTE DECRETO SERA DE ($1.172) PARA EL DEVENGADO MES DE ENERO DE 2025 .\n\nOBSERVACION: POR DISPOSICION 2/2025 DE LA SUPERINTENDENCIA DE RIESGOS DEL TRABAJO GERENCIA DE CONTROL PRESTACIONAL (B.O. 14/02/2025) SE ESTABLECE QUE EL VALOR DE LA SUMA FIJA PREVISTA EN EL ART. 5 DEL PRESENTE DECRETO SERA DE ($1.196) PARA EL DEVENGADO MES DE FEBRERO DE 2025 .\n\nOBSERVACION: POR DISPOSICION 3/2025 DE LA SUPERINTENDENCIA DE RIESGOS DEL TRABAJO GERENCIA DE CONTROL PRESTACIONAL (B.O. 26/03/2025) SE ESTABLECE QUE EL VALOR DE LA SUMA FIJA PREVISTA EN EL ART. 5 DEL PRESENTE DECRETO SERA DE ($1.227)PARA EL DEVENGADO MES DE MARZO DE 2025 ."
+      },
+      "descriptores": {
+        "descriptor": [
+          {
+            "elegido": {
+              "termino": "accidentes de trabajo"
+            },
+            "preferido": {
+              "termino": "Derecho laboral/accidentes de trabajo"
+            },
+            "sinonimos": {
+              "termino": [
+                "derecho del trabajo",
+                "accidentes y enfermedades de trabajo"
+              ]
+            }
+          },
+          {
+            "elegido": {
+              "termino": "enfermedad profesional"
+            },
+            "preferido": {
+              "termino": "Derecho laboral/accidentes de trabajo/enfermedad profesional"
+            },
+            "sinonimos": {
+              "termino": [
+                "derecho del trabajo",
+                "enfermedad laboral",
+                "accidentes y enfermedades de trabajo"
+              ]
+            }
+          },
+          {
+            "elegido": {
+              "termino": "asegurador por riesgos del trabajo"
+            },
+            "preferido": {
+              "termino": "Derecho laboral/accidentes de trabajo/riesgos del trabajo/seguro por accidente de trabajo/asegurador por riesgos del trabajo"
+            },
+            "sinonimos": {
+              "termino": [
+                "derecho del trabajo",
+                "aseguradora de riesgos del trabajo",
+                "ART",
+                "seguro de riesgos del trabajo",
+                "accidentes y enfermedades de trabajo",
+                "aseguradora de riesgos"
+              ]
+            }
+          },
+          {
+            "elegido": {
+              "termino": "FONDO PARA FINES ESPECÍFICOS"
+            },
+            "preferido": {
+              "termino": "FONDO PARA FINES ESPECÍFICOS"
+            },
+            "sinonimos": null
+          }
+        ],
+        "suggest": {
+          "termino": [
+            "accidentes de trabajo",
+            "seguro de riesgos del trabajo (seguro por accidente de trabajo)",
+            "enfermedad profesional",
+            "accidentes y enfermedades de trabajo (accidentes de trabajo)",
+            "asegurador por riesgos del trabajo",
+            "ART (asegurador por riesgos del trabajo)",
+            "riesgos del trabajo",
+            "derecho del trabajo (Derecho laboral)",
+            "FONDO PARA FINES ESPECÍFICOS",
+            "enfermedad laboral (enfermedad profesional)",
+            "Derecho laboral",
+            "aseguradora de riesgos del trabajo (asegurador por riesgos del trabajo)",
+            "aseguradora de riesgos (asegurador por riesgos del trabajo)",
+            "seguro por accidente de trabajo"
+          ]
+        }
+      },
+      "visto": {
+        "referencias-normativas": {
+          "referencia-normativa": [
+            {
+              "cr": null,
+              "id": "REFERENCIAS_NORMATIVAS_0",
+              "ref": "LEY C 024241 1993 09 23 0000 000 0000 000"
+            },
+            {
+              "cr": null,
+              "id": "REFERENCIAS_NORMATIVAS_1",
+              "ref": "LEY C 024557 1995 09 13 0000 000 0000 000"
+            },
+            {
+              "cr": null,
+              "id": "REFERENCIAS_NORMATIVAS_2",
+              "ref": "DEC C 000170 1996 02 21 0000 000 0000 000"
+            },
+            {
+              "cr": null,
+              "id": "REFERENCIAS_NORMATIVAS_3",
+              "ref": "DEC C 000659 1996 06 24 0000 000 0000 000"
+            },
+            {
+              "cr": null,
+              "id": "REFERENCIAS_NORMATIVAS_4",
+              "ref": "DEC C 000717 1996 06 28 0000 000 0000 000"
+            },
+            {
+              "cr": null,
+              "id": "REFERENCIAS_NORMATIVAS_5",
+              "ref": "DEC C 001338 1996 11 25 0000 000 0000 000"
+            }
+          ]
+        },
+        "texto": "el Expediente del Registro de la Superintendencia de Riesgos del Trabajo SRT N. 0235/97 dependiente del MINISTERIO DE TRABAJO Y SEGURIDAD SOCIAL, las Leyes N. 24.241, N. 24.557 y los Decretos N.\n\n170 de fecha 21 de febrero de 1996, N. 659 de fecha 24 de junio de 1996, el N. 717 del 28 de junio de 1996 y el Decreto N. 1.338 de fecha 25 de noviembre de 1996, y"
+      },
+      "considerando": {
+        "referencias-normativas": {
+          "referencia-normativa": [
+            {
+              "cr": null,
+              "id": "REFERENCIAS_NORMATIVAS_0",
+              "ref": "LEY C 024557 1995 09 13 0000 000 0000 000"
+            },
+            {
+              "cr": null,
+              "id": "REFERENCIAS_NORMATIVAS_1",
+              "ref": "LEY C 024557 1995 09 13 0049 000 0000 000"
+            },
+            {
+              "cr": null,
+              "id": "REFERENCIAS_NORMATIVAS_2",
+              "ref": "DEC C 000170 1996 02 21 0015 000 0000 000"
+            },
+            {
+              "cr": null,
+              "id": "REFERENCIAS_NORMATIVAS_3",
+              "ref": "DEC C 000659 1996 06 24 0000 000 0000 000"
+            }
+          ]
+        },
+        "sancion": "EL PRESIDENTE DE LA NACION ARGENTINA DECRETA:",
+        "texto": "Que la Ley N. 24.557 sobre Riesgos del Trabajo (L.R.T.) establece que las prestaciones correspondientes a las enfermedades laborales incluidas en el listado aprobado estarán a cargo de las ASEGURADORAS DE RIESGOS DEL TRABAJO (A.R.T.) y Compañías de Seguros previstas en el artículo 49 disposición adicional 4 de la misma Ley a la que el empleador se encuentre afiliado, a menos que el empleador hubiere optado por el régimen de autoseguro o que la relación laboral con el damnificado se hubiere extinguido con anterioridad a la afiliación del empleador a la Aseguradora.\n\nQue la información disponible, señala la existencia de un conjunto de enfermedades profesionales que conforman un pasivo oculto en el sistema productivo argentino.\n\nQue existen enfermedades de baja frecuencia pero de gravedad significativa y otras de menor gravedad pero de alta frecuencia y masividad.\n\nQue desde el punto de vista económico, las segundas resultan las de mayor impacto sobre el sistema.\n\nQue de ellas se destacan, las enfermedades profesionales del tipo hipoacusias perceptivas provocadas por exposición a los agentes de riesgo establecidos en el listado de enfermedades profesionales y demás instrumentos establecidos a través de la reglamentación de la L.R.T.\n\nQue las investigaciones y los estudios realizados señalan, también, que las hipoacusias perceptivas con las características indicadas en el párrafo precedente podrían implicar prestaciones dinerarias por montos muy significativos en relación a la recaudación total del sistema, aumentando, consecuentemente, las posibilidades de que se generen situaciones conflictivas.\n\nQue además la transición entre el antiguo régimen y el nuevo sistema no deben afectar el principio prioritario de garantizar a los trabajadores las prestaciones previstas en la L.R.T. en tiempo y forma, sin que ello produzca un aumento substantivo de los costos laborales para los empleadores.\n\nQue, tal como lo muestra la experiencia internacional, resulta recomendable crear un fondo especial a través del cual se garanticen los recursos para hacer frente a las prestaciones dinerarias que deben percibir los trabajadores en virtud de riesgos del trabajo.\n\nQue las estimaciones efectuadas, a partir de las actividades en donde los trabajadores se encuentran expuestos a los riesgos establecidos por la normativa de la L.R.T., y aplicando las estimaciones de los pagos por incapacidad resultantes de los instrumentos establecidos en el Decreto N. 659/96, permiten cuantificar que el monto estimado que como mínimo deberían integrar las aseguradoras a un fondo de fines específicos resultaría de una magnitud de PESOS SESENTA CENTAVOS ($ 0,60) mensuales.\n\nQue el artículo 15 del Decreto N. 170/96 establece que las alícuotas deberán incluir indicadores de siniestralidad presunta, que para este caso en particular devendría en siniestralidad presunta de hipocausias, que según las estimaciones preliminares serían de una magnitud mínima estimada en PESOS SESENTA CENTAVOS ($0,60) mensuales por trabajador incluido en el plantel del empleador afiliado.\n\nQue razones operativas, hacen recomendable que los exámenes para la detección de las hipoacusias se desarrollen en un período que permita garantizar a los trabajadores el adecuado cumplimiento de los mismos, manteniendo los criterios de inmediatez y objetividad en la evaluación de las incapacidades.\n\nQue la presente medida se dicta en uso de las facultades conferidas por el artículo 99, inciso 2, de la CONSTITUCION NACIONAL.\n\nPor ello,"
+      },
+      "articulo": [
+        {
+          "referencias-normativas": {
+            "referencia-normativa": {
+              "cr": null,
+              "id": "REFERENCIAS_NORMATIVAS_0",
+              "ref": "LEY C 024557 1995 09 13 0000 000 0000 000"
+            }
+          },
+          "numero-articulo": 1,
+          "texto": "*Art. 1: FONDO FIDUCIARIO DE ENFERMEDADES PROFESIONALES.\n\nCréase un fondo consolidado provisional que se denominará FONDO FIDUCIARIO DE ENFERMEDADES PROFESIONALES que deberán administrar las Aseguradoras de Riesgos del Trabajo, conforme lo establezca la reglamentación, y que servirá como herramienta para asistir al correcto funcionamiento del sistema de prestaciones previsto en la Ley N. 24.557.",
+          "modificado-por": {
+            "referencia-normativa": {
+              "cr": "(B.O. 03/01/2001) Artículo sustituido.",
+              "id": "MODIFICADO_POR_0",
+              "ref": "DNU C 001278 2000 12 28 0001 000 0000 000"
+            }
+          }
+        },
+        {
+          "referencias-normativas": {
+            "referencia-normativa": {
+              "cr": null,
+              "id": "REFERENCIAS_NORMATIVAS_0",
+              "ref": "LEY C 024557 1995 09 13 0006 000 0000 000"
+            }
+          },
+          "numero-articulo": 2,
+          "texto": "*Art. 2: APLICACION.\n\nTransitoriamente y hasta tanto se disponga lo contrario, el Fondo Fiduciario de Enfermedades Profesionales tendrá los siguientes destinos:\n\na) abonar las prestaciones dinerarias correspondientes a hipoacusias perceptivas consideradas según lo estipulado en el artículo 6, apartado 2 a) de la Ley N. 24.557 y su normativa reglamentaria.\n\nb) el costo de las prestaciones otorgadas por enfermedades no incluidas en el listado previsto en el artículo 6, apartado 2 a) de la Ley N. 24.557, aunque reconocidas como de naturaleza profesional, conforme las disposiciones contenidas en el artículo 6, apartado 2 b) de la misma ley, hasta que resulten incluidas en el listado de enfermedades profesionales, se abonará exclusivamente con los recursos del Fondo creado por el presente Decreto.\n\nc) el costo de las prestaciones otorgadas por enfermedades que se incluyan a partir de la fecha de vigencia de la presente incorporación en el listado previsto en el artículo 6°, apartado 2 a) de la Ley Nº 24.557; en un CIENTO POR CIENTO (100%) el primer año y un CINCUENTA POR CIENTO (50%) el segundo año, a contar desde su inclusión en el Listado de Enfermedades Profesionales. A partir del tercer año, las prestaciones estarán íntegramente a cargo de las Aseguradoras de Riesgos del Trabajo.\n\nd) el pago de los intereses, amortizaciones y demás costos de administración correspondientes a la cancelación de las deudas contraídas con el objeto de financiar el pago de las prestaciones indicadas en los incisos anteriores, mediante el uso de fuentes de crédito a las que hubiere sido autorizado acceder, conforme las condiciones que establezca la Superintendencia de Seguros de la Nación, en su calidad de Autoridad de Aplicación.",
+          "modificado-por": {
+            "referencia-normativa": [
+              {
+                "cr": "(B.O. 20/01/2014) Inc. c) incorporado.",
+                "id": "MODIFICADO_POR_0",
+                "ref": "DEC C 000049 2014 01 14 0003 000 0000 000"
+              },
+              {
+                "cr": "(B.O. 03/01/2001) Artículo sustituido.",
+                "id": "MODIFICADO_POR_1",
+                "ref": "DNU C 001278 2000 12 28 0000 000 0000 000"
+              },
+              {
+                "cr": "(B.O. 18/02/2022) Inciso d) incorporado.",
+                "id": "MODIFICADO_POR_2",
+                "ref": "DEC C 000079 2022 02 17 0004 000 0000 000"
+              }
+            ]
+          }
+        },
+        {
+          "numero-articulo": 3,
+          "texto": "*Art. 3: UTILIZACION DEL FONDO.\n\nAl sólo efecto del pago de las prestaciones dinerarias correspondientes a hipoacusias perceptivas consideradas según lo estipulado en el artículo 6, apartado 2 a) de la Ley N.\n\n24.557 y su normativa reglamentaria, las aseguradoras podrán utilizar el Fondo Fiduciario de Enfermedades Profesionales en una proporción según la fecha en que se abone la prestación dineraria y que surgirá de aplicar el factor G que se detalla a continuación, sobre la base de la siguiente tabla.\n\n Período dentro del cual se abonó la G  prestación dineraria por hipoacusia Desde el 1/7/1996 al 30/6/1998 1  Desde el 1/7/1998 al 30/6/1999 0.95  Desde el 1/7/1999 al 30/6/2000 0.90  Desde el 1/7/2000 al 30/6/2001 0.85  Desde el 1/7/2001 al 30/6/2002 0.80  Desde el 1/7/2002 al 30/6/2003 0.75  Desde el 1/7/2003 al 30/6/2004 0.70  Desde el 1/7/2004 al 30/6/2005 0.65  Desde el 1/7/2005 al 30/6/2006 0.60  Desde el 1/7/2006 al 30/6/2007 0.55  Desde el 1/7/2007 al 30/6/2008 0.50  Desde el 1/7/2008 al 30/6/2009 0.45  Desde el 1/7/2009 al 30/6/2010 0.40  Desde el 1/7/2010 al 30/6/2011 0.35  Desde el 1/7/2011 al 30/6/2012 0.30  Desde el 1/7/2012 al 30/6/2013 0.25  Desde el 1/7/2013 al 30/6/2014 0.20  Desde el 1/7/2014 al 30/6/2015 0.15  Desde el 1/7/2015 al 30/6/2016 0.10  Desde el 1/7/2016 al 30/6/2017 0.05  Desde el 1/7/2017 en adelante 0.00",
+          "modificado-por": {
+            "referencia-normativa": {
+              "cr": "(B.O. 03/01/2001) Primer párrafo sustituido.",
+              "id": "MODIFICADO_POR_0",
+              "ref": "DNU C 001278 2000 12 28 0000 000 0000 000"
+            }
+          }
+        },
+        {
+          "numero-articulo": 4,
+          "texto": "*Art. 4: FINANCIAMIENTO. El Fondo Fiduciario de Enfermedades Profesionales se financiará con los siguientes recursos:\n\na) Una porción de cada alícuota de afiliación percibida en los contratos que se renueven, prorroguen o inicien con posterioridad a la fecha del presente Decreto.\n\nb) La rentabilidad que eventualmente pueda producir la inversión de los mencionados recursos.\n\nc) El saldo del Fondo para Fines Específicos creado por cada aseguradora de conformidad con lo dispuesto por el artículo 1 del presente Decreto en su redacción original (B.O. 4/7/97), que deberá ser transferido en el plazo que fije la autoridad de aplicación.\n\nd) Los derivados de operaciones de financiamiento realizadas a través de los instrumentos previstos en el Libro Tercero, Título IV, Capítulo 30 del CÓDIGO CIVIL Y COMERCIAL DE LA NACIÓN, incluida la emisión de títulos valores con o sin oferta pública.\n\ne) Los obtenidos mediante el acceso a operaciones de crédito.\n\nf) Otros ingresos, aportes, contribuciones, subsidios, legados o donaciones que específicamente se le destinen.\n\nEl acceso a las fuentes de financiamiento previstas en los incisos d) y e) precedentes solo podrá tener por objeto financiar el pago de las prestaciones indicadas en los incisos a), b) y c) del artículo 2° y requerirá de la previa intervención de la SUPERINTENDENCIA DE SEGUROS DE LA NACIÓN, en su carácter de Autoridad de Aplicación.",
+          "modificado-por": {
+            "referencia-normativa": [
+              {
+                "cr": "(B.O. 03/01/2001) Artículo sustituido.",
+                "id": "MODIFICADO_POR_0",
+                "ref": "DNU C 001278 2000 12 28 0000 000 0000 000"
+              },
+              {
+                "cr": "B.O. 18/02/2022) Incisos d), e), f) y último párrafo incorporados.",
+                "id": "MODIFICADO_POR_1",
+                "ref": "DEC C 000079 2022 02 17 0005 000 0000 000"
+              }
+            ]
+          }
+        },
+        {
+          "numero-articulo": 5,
+          "texto": "Art. 5: Agréguese a continuación del segundo párrafo del artículo 15 del Decreto Nº 170/96 lo siguiente:.\n\n\"Integrará también la alícuota, una suma fija por cada trabajador, de un valor mínimo de PESOS SESENTA CENTAVOS ($ 0,60), destinada al financiamiento del FONDO para FINES ESPECIFICOS\".",
+          "observado-por": {
+            "referencia-normativa": [
+              {
+                "cr": "(B.O. 10/03/2021) Por Resolución del Ministerio de Trabajo, Empleo y Seguridad Social se dispone que la suma fija a abonar por cada trabajador conjuntamente con la alícuota, establecida en el presente artículo con destino al Fondo Fiduciario de Enfermedades Profesionales (FFEP), será de un valor de ($ 40.-).",
+                "id": "OBSERVADO_POR_0",
+                "ref": "RES C 000115 2021 03 09 0001 000 0000 000"
+              },
+              {
+                "cr": "(B.O. 11/08/2021) Por Resolución del Ministerio de Trabajo, Empleo y Seguridad Social se establece que el valor de la suma fija prevista en el presente Artículo se incrementará trimestralmente según la variación de la Remuneración Imponible Promedio de los Trabajadores Estables (RIPTE) -Índice no decreciente-.",
+                "id": "OBSERVADO_POR_1",
+                "ref": "RES C 000467 2021 08 10 0000 000 0000 000"
+              },
+              {
+                "cr": "(B.O. 2/09/2021) Por Resolución de la Superintendencia de Riesgos del Trabajo se establece que el valor de la suma fija prevista en el presente Artículo será de ($ 45,07)para el devengado del mes de julio.",
+                "id": "OBSERVADO_POR_2",
+                "ref": "RES C 000047 2021 08 31 0001 000 0000 000"
+              },
+              {
+                "cr": "(B.O. 14/06/2022) Por Resolución del Ministerio de Trabajo, Empleo y Seguridad Social se establece que el valor de la suma fija prevista en el presente Artículo será de ($ 127,65))para las obligaciones con vencimiento a partir del mes de julio de 2022.",
+                "id": "OBSERVADO_POR_3",
+                "ref": "RES C 000649 2022 06 13 0001 000 0000 000"
+              },
+              {
+                "cr": "(B.O. 18/08/2022) Por Disposición de la Superintendencia de Riesgos del Trabajo- Gerencia de Control Prestacional se establece que el valor de la suma fija prevista en el presente artículo será de ($ 141) para el devengado del mes de agosto de 2022.",
+                "id": "OBSERVADO_POR_4",
+                "ref": "DIS C 000004 2022 08 17 0001 000 0000 000"
+              },
+              {
+                "cr": "(B.O. 27/12/2022) Por Disposición de la Superintendencia de Riesgos del Trabajo- Gerencia de Control Prestacional se establece que el valor de la suma fija prevista en el presente artículo será de ($ 173) para el devengado del mes de diciembre de 2022.",
+                "id": "OBSERVADO_POR_5",
+                "ref": "DIS C 000008 2022 12 22 0001 000 0000 000"
+              },
+              {
+                "cr": "(B.O. 20/01/2023) Por Disposición de la Superintendencia de Riesgos del Trabajo Gerencia de Control Prestacional se establece que el valor de la suma fija prevista en el presente artículo será de ($ 183) para el devengado del mes de Enero de 2023.",
+                "id": "OBSERVADO_POR_6",
+                "ref": "DIS C 000001 2023 01 18 0001 000 0000 000"
+              },
+              {
+                "cr": "(B.O. 12/5/2023) POR RESOLUCION DE LA SUPERINTENDENCIA DE RIESGOS DEL TRABAJO GERENCIA DE CONTROL PRESTACIONAL SE ESTABLECE EL VALOR DE LA SUMA FIJA EN ($238) PARA EL MES DE MAYO.",
+                "id": "OBSERVADO_POR_7",
+                "ref": "DIS C 000005 2023 05 10 0000 000 0000 000"
+              },
+              {
+                "cr": "(B.O. 21/06/2023) Por Disposición de la Superintendencia de Riesgos del Trabajo Gerencia de Control Prestacional se establece que el valor de la suma fija prevista en el presente artículo será de ($ 262) para el devengado del mes de junio de 2023.",
+                "id": "OBSERVADO_POR_8",
+                "ref": "DIS C 000006 2023 06 15 0001 000 0000 000"
+              },
+              {
+                "cr": "(B.O. 14/08/2023) Por Disposición de la Superintendencia de Riesgos del Trabajo Gerencia de Control Prestacional se establece que el valor de la suma fija prevista en el presente artículo será de ($ 301) para el devengado del mes de Agosto de 2023.",
+                "id": "OBSERVADO_POR_9",
+                "ref": "DIS C 000008 2023 08 10 0001 000 0000 000"
+              },
+              {
+                "cr": "(B.O. 15/12/2023) Por Disposición de la Superintendencia de Riesgos del Trabajo Gerencia de Control Prestacional se establece que el valor de la suma fija prevista en el presente artículo será de ($418)) para el devengado del mes de Diciembre de 2023.",
+                "id": "OBSERVADO_POR_10",
+                "ref": "DIS C 000012 2023 12 14 0001 000 0000 000"
+              }
+            ]
+          }
+        },
+        {
+          "referencias-normativas": {
+            "referencia-normativa": {
+              "cr": null,
+              "id": "REFERENCIAS_NORMATIVAS_0",
+              "ref": "DEC C 000170 1996 02 21 0015 000 0000 000"
+            }
+          },
+          "numero-articulo": 6,
+          "texto": "Art. 6: La integración a las alícuotas pactadas de una suma de PESOS SESENTA CENTAVOS ($ 0,60) por cada trabajador del empleador afiliado, con destino al FONDO para FINES ESPECIFICOS, no podrá ser considerada, en modo alguno, a los efectos de la aplicación de las disposiciones contenidas en el cuarto, quinto y sexto párrafo del artículo 15 del Decreto N. 170/96."
+        },
+        {
+          "numero-articulo": 7,
+          "texto": "Art. 7: AUTORIDAD DE APLICACION.\n\nLa S.S.N. será la autoridad de aplicación del presente en los aspectos relativos a la administración de los recursos del FONDO para FINES ESPECIFICOS, y la SUPERINTENDENCIA DE RIESGOS DEL TRABAJO (S.R.T.) lo será respecto a la aplicación y utilización de dichos recursos. Por Resolución Conjunta de ambos organismos, se reglamentará la metodología para determinar los excedentes del FONDO para FINES ESPECIFICOS."
+        },
+        {
+          "numero-articulo": 8,
+          "texto": "Art. 8: COMITE DE SEGUIMIENTO.\n\nEl Comité Consultivo Permanente será el encargado de monitorear el adecuado cumplimiento de los objetivos del FONDO para FINES ESPECIFICOS. A tales fines podrá proponer la inclusión de otras enfermedades profesionales de las establecidas en la Lista de Enfermedades Profesionales, el destino de los excedentes a otros fines, y la reducción o eliminación del fondo creado por el presente Decreto en el caso de que resultase excedentario de manera recurrente."
+        },
+        {
+          "derogado-por": {
+            "referencia-normativa": {
+              "cr": "(B.O. 03/01/2001) Artículo derogado.",
+              "id": "DEROGADO_POR_0",
+              "ref": "DNU C 001278 2000 12 28 0018 000 0000 000"
+            }
+          },
+          "numero-articulo": 9,
+          "texto": "Art. 9: Nota de Redacción: Derogado por art. 18 del Decreto 1.278/2000."
+        },
+        {
+          "numero-articulo": 10,
+          "texto": "Art. 10: Comuníquese, publíquese, dése a la Dirección Nacional del Registro Oficial y archívese."
+        }
+      ],
+      "firmantes": {
+        "firmantes": "FIRMANTES"
+      },
+      "id-infojus": "DN19970000590",
+      "fecha-umod": 20250326134612
+    }
+  }
+}

--- a/src/Tests/Argentina/SaijSamples/Diff/123456789-0abc-095-0000-7991soterced-old.json
+++ b/src/Tests/Argentina/SaijSamples/Diff/123456789-0abc-095-0000-7991soterced-old.json
@@ -1,0 +1,381 @@
+{
+  "document": {
+    "metadata": {
+      "uuid": "123456789-0abc-095-0000-7991soterced",
+      "document-content-type": "legislacion",
+      "timestamp": 1743007571536,
+      "operation": "ADD",
+      "target-document-repository-id": "infojus",
+      "target-index-id": "index",
+      "target-document-indexing-id": "legislacion",
+      "document-recovery-strategy": "abstract-legislacion",
+      "friendly-url": {
+        "subdomain": "decreto",
+        "description": "590-nacional-creacion-fondo-para-fines-especificos-marco-ley-riesgos-trabajo-dn19970000590-1997-06-30"
+      }
+    },
+    "content": {
+      "mecanografico": 19970000590,
+      "estado": "Vigente, de alcance general",
+      "tipo-norma": {
+        "codigo": "DEC",
+        "texto": "Decreto"
+      },
+      "numero-norma": 590,
+      "fecha": "1997-06-30",
+      "jurisdiccion": {
+        "codigo": "C",
+        "descripcion": "Nacional",
+        "capital": "Capital Federal",
+        "id-pais": 11
+      },
+      "standard-normativo": "DEC C 000590 1997 06 30",
+      "titulo-norma": "Creación del Fondo para Fines Específicos en el Marco de la Ley de Riesgos del Trabajo",
+      "nombre-coloquial": "DECRETO NACIONAL 590/1997",
+      "lugar-emision": "BUENOS AIRES",
+      "publicacion-codificada": {
+        "publicacion-decodificada": {
+          "organismo": "Boletín Oficial",
+          "fecha": "1997 07 04"
+        }
+      },
+      "analista": "Quintana, Carolina",
+      "responsable": "Quintana, Carolina",
+      "uid-alta": "ABM",
+      "uid-mod": "ABM",
+      "fecha-alta": "2025-03-26",
+      "fecha-mod": "2025-03-26",
+      "timestamp": "2025-03-26T13:39:25",
+      "timestamp-alta": "2025-03-26T13:39:25",
+      "timestamp-m": "2025-03-26T13:39:25",
+      "generalidades": {
+        "sintesis": "SE ESTABLECE, EN EL MARCO DE LA LEY DE RIESGOS DEL TRABAJO, LA CREACION DE UN FONDO PROVISIONAL QUE SE DENOMINARA \"FONDO PARA FINES ESPECIFICOS\".",
+        "observaciones-generales": "CANTIDAD DE ARTICULOS QUE COMPONEN LA NORMA: 10.\n\nOBSERVACION: POR DISPOSICION 2/2021 DE LA SUPERINTENDENCIA DE RIESGOS DEL TRABAJO GERENCIA DE CONTROL PRESTACIONAL (B.O. 27/10/2021) SE ESTABLECE QUE EL VALOR DE LA SUMA FIJA PREVISTA EN EL ART. 5 DEL PRESENTE DECRETO SERA DE ($ 49,98) PARA EL MES DE OCTUBRE Y SE ABONARA A PARTIR DE NOVIEMBRE DE 2021.\n\nOBSERVACION: POR RESOLUCION 794/2021 DEL MINISTERIO DE TRABAJO, EMPLEO Y SEGURIDAD SOCIAL(B.O. 7/12/2021) SE ESTABLECE QUE EL VALOR DE LA SUMA FIJA PREVISTA EN EL ART. 5 DEL PRESENTE DECRETO SERA DE ($100,00) A PARTIR DEL MES DE FEBRERO 2022 SOBRE LOS HABERES DEVENGADOS EN EL MES DE ENERO DE 2022 .\n\nOBSERVACION: POR DISPOSICION 2/2022 DE LA SUPERINTENDENCIA DE RIESGOS DEL TRABAJO GERENCIA DE CONTROL PRESTACIONAL (B.O. 28/04/2022) SE ESTABLECE QUE EL VALOR DE LA SUMA FIJA PREVISTA EN EL ART. 5 DEL PRESENTE DECRETO SERA DE ($111,75) PARA EL DEVENGADO MES DE ABRIL DE 2022 .\n\nOBSERVACION: POR DISPOSICION 3/2022 DE LA SUPERINTENDENCIA DE RIESGOS DEL TRABAJO GERENCIA DE CONTROL PRESTACIONAL (B.O. 19/07/2022) SE ESTABLECE QUE EL VALOR DE LA SUMA FIJA PREVISTA EN EL ART. 5 DEL PRESENTE DECRETO SERA DE ($133) PARA EL DEVENGADO MES DE JULIO DE 2022 .\n\nOBSERVACION: POR RESOLUCION CONJUNTA 1/22 DE LA SUPERINTENDENCIA DE SERVICIOS DE SALUD Y SUPERINTENDENCIA DE SEGUROS DE LA NACIÓN Y SUPERINTENDENCIA DE RIESGOS DEL TRABAJO (B.O. 10/8/2022) SE APRUEBA EL RÉGIMEN EXTRAORDINARIO DE PAGOS DE EROGACIONES EFECTUADAS POR LAS OBRAS SOCIALES A CUENTA DE LOS FONDOS PROVENIENTES DEL FONDO FIDUCIARIO DE ENFERMEDADES PROFESIONALES -CREADO POR EL PRESENTE DECRETO - PARA AFRONTAR LOS COSTOS DE LAS PRESTACIONES MÉDICO ASISTENCIALES VINCULADAS CON LA ENFERMEDAD PRODUCIDA POR EL CORONAVIRUS SARS-CoV-2.\n\nOBSERVACION: POR DISPOSICION 6/2022 DE LA SUPERINTENDENCIA DE RIESGOS DEL TRABAJO GERENCIA DE CONTROL PRESTACIONAL (B.O. 27/10/2022) SE ESTABLECE QUE EL VALOR DE LA SUMA FIJA PREVISTA EN EL ART. 5 DEL PRESENTE DECRETO SERA DE ($155) PARA EL DEVENGADO MES DE OCTUBRE DE 2022 .\n\nOBSERVACION: POR DISPOSICION 7/2022 DE LA SUPERINTENDENCIA DE RIESGOS DEL TRABAJO GERENCIA DE CONTROL PRESTACIONAL (B.O. 24/11/2022) SE ESTABLECE QUE EL VALOR DE LA SUMA FIJA PREVISTA EN EL ART. 5 DEL PRESENTE DECRETO SERA DE ($164) PARA EL DEVENGADO MES DE NOVIEMBRE DE 2022 .\n\nOBSERVACION: POR DISPOSICION 7/2023 DE LA SUPERINTENDENCIA DE RIESGOS DEL TRABAJO GERENCIA DE CONTROL PRESTACIONAL (B.O. 24/7/2023) SE ESTABLECE QUE EL VALOR DE LA SUMA FIJA PREVISTA EN EL ART. 5 DEL PRESENTE DECRETO SERA DE ($278) PARA EL DEVENGADO MES DE JULIO DE 2023 .\n\nOBSERVACION: POR DISPOSICION 9/2023 DE LA SUPERINTENDENCIA DE RIESGOS DEL TRABAJO GERENCIA DE CONTROL PRESTACIONAL (B.O. 20/9/2023) SE ESTABLECE QUE EL VALOR DE LA SUMA FIJA PREVISTA EN EL ART. 5 DEL PRESENTE DECRETO SERA DE ($323) PARA EL DEVENGADO MES DE SEPTIEMBRE DE 2023 .\n\nOBSERVACION: POR DISPOSICION 10/2023 DE LA SUPERINTENDENCIA DE RIESGOS DEL TRABAJO GERENCIA DE CONTROL PRESTACIONAL (B.O. 17/10/2023) SE ESTABLECE QUE EL VALOR DE LA SUMA FIJA PREVISTA EN EL ART. 5 DEL PRESENTE DECRETO SERA DE ($342) PARA EL DEVENGADO MES DE OCTUBRE DE 2023 .\n\nOBSERVACION: POR DISPOSICION 11/2023 DE LA SUPERINTENDENCIA DE RIESGOS DEL TRABAJO GERENCIA DE CONTROL PRESTACIONAL (B.O. 17/11/2023) SE ESTABLECE QUE EL VALOR DE LA SUMA FIJA PREVISTA EN EL ART. 5 DEL PRESENTE DECRETO SERA DE ($374) PARA EL DEVENGADO MES DE NOVIEMBRE DE 2023 .\n\nOBSERVACION: POR DISPOSICION 1/2024 DE LA SUPERINTENDENCIA DE RIESGOS DEL TRABAJO GERENCIA DE CONTROL PRESTACIONAL (B.O. 18/1/2024) SE ESTABLECE QUE EL VALOR DE LA SUMA FIJA PREVISTA EN EL ART. 5 DEL PRESENTE DECRETO SERA DE ($444) PARA EL DEVENGADO MES DE ENERO DE 2024 .\n\nOBSERVACION: POR DISPOSICION 5/2024 DE LA SUPERINTENDENCIA DE RIESGOS DEL TRABAJO GERENCIA DE CONTROL PRESTACIONAL (B.O. 20/5/2024) SE ESTABLECE QUE EL VALOR DE LA SUMA FIJA PREVISTA EN EL ART. 5 DEL PRESENTE DECRETO SERA DE ($ 702) PARA EL DEVENGADO MES DE MAYO 2024 .\n\nOBSERVACION: POR DISPOSICION 6/2024 DE LA SUPERINTENDENCIA DE RIESGOS DEL TRABAJO GERENCIA DE CONTROL PRESTACIONAL (B.O. 26/6/2024) SE ESTABLECE QUE EL VALOR DE LA SUMA FIJA PREVISTA EN EL ART. 5 DEL PRESENTE DECRETO SERA DE ($ 815) PARA EL DEVENGADO MES DE JUNIO DE 2024 .\n\nOBSERVACION: POR DISPOSICION 7/2024 DE LA SUPERINTENDENCIA DE RIESGOS DEL TRABAJO GERENCIA DE CONTROL PRESTACIONAL (B.O. 29/7/2024) SE ESTABLECE QUE EL VALOR DE LA SUMA FIJA PREVISTA EN EL ART. 5 DEL PRESENTE DECRETO SERA DE ($874) PARA EL DEVENGADO MES DE JULIO DE 2024 .\n\nOBSERVACION: POR DISPOSICION 8/2024 DE LA SUPERINTENDENCIA DE RIESGOS DEL TRABAJO GERENCIA DE CONTROL PRESTACIONAL (B.O. 22/8/2024) SE ESTABLECE QUE EL VALOR DE LA SUMA FIJA PREVISTA EN EL ART. 5 DEL PRESENTE DECRETO SERA DE ($928) PARA EL DEVENGADO MES DE AGOSTO DE 2024 .\n\nOBSERVACION: POR DISPOSICION 9/2024 DE LA SUPERINTENDENCIA DE RIESGOS DEL TRABAJO GERENCIA DE CONTROL PRESTACIONAL (B.O. 27/9/2024) SE ESTABLECE QUE EL VALOR DE LA SUMA FIJA PREVISTA EN EL ART. 5 DEL PRESENTE DECRETO SERA DE ($989) PARA EL DEVENGADO MES DE SEPTIEMBRE DE 2024 .\n\nOBSERVACION: POR DISPOSICION 10/2024 DE LA SUPERINTENDENCIA DE RIESGOS DEL TRABAJO GERENCIA DE CONTROL PRESTACIONAL (B.O. 25/10/2024) SE ESTABLECE QUE EL VALOR DE LA SUMA FIJA PREVISTA EN EL ART. 5 DEL PRESENTE DECRETO SERA DE ($1.026) PARA EL DEVENGADO MES DE OCTUBRE DE 2024 .\n\nOBSERVACION: POR DISPOSICION 11/2024 DE LA SUPERINTENDENCIA DE RIESGOS DEL TRABAJO GERENCIA DE CONTROL PRESTACIONAL (B.O. 25/11/2024) SE ESTABLECE QUE EL VALOR DE LA SUMA FIJA PREVISTA EN EL ART. 5 DEL PRESENTE DECRETO SERA DE ($1.069) PARA EL DEVENGADO MES DE NOVIEMBRE DE 2024 .\n\nOBSERVACION: POR DISPOSICION 12/2024 DE LA SUPERINTENDENCIA DE RIESGOS DEL TRABAJO GERENCIA DE CONTROL PRESTACIONAL (B.O. 26/12/2024) SE ESTABLECE QUE EL VALOR DE LA SUMA FIJA PREVISTA EN EL ART. 5 DEL PRESENTE DECRETO SERA DE ($1.140) PARA EL DEVENGADO MES DE DICIEMBRE DE 2024 .\n\nOBSERVACION: POR DISPOSICION 1/2025 DE LA SUPERINTENDENCIA DE RIESGOS DEL TRABAJO GERENCIA DE CONTROL PRESTACIONAL (B.O. 17/01/2025) SE ESTABLECE QUE EL VALOR DE LA SUMA FIJA PREVISTA EN EL ART. 5 DEL PRESENTE DECRETO SERA DE ($1.172) PARA EL DEVENGADO MES DE ENERO DE 2025 .\n\nOBSERVACION: POR DISPOSICION 2/2025 DE LA SUPERINTENDENCIA DE RIESGOS DEL TRABAJO GERENCIA DE CONTROL PRESTACIONAL (B.O. 14/02/2025) SE ESTABLECE QUE EL VALOR DE LA SUMA FIJA PREVISTA EN EL ART. 5 DEL PRESENTE DECRETO SERA DE ($1.196) PARA EL DEVENGADO MES DE FEBRERO DE 2025 .\n\nOBSERVACION: POR DISPOSICION 3/2025 DE LA SUPERINTENDENCIA DE RIESGOS DEL TRABAJO GERENCIA DE CONTROL PRESTACIONAL (B.O. 26/03/2025) SE ESTABLECE QUE EL VALOR DE LA SUMA FIJA PREVISTA EN EL ART. 5 DEL PRESENTE DECRETO SERA DE ($1.227)PARA EL DEVENGADO MES DE MARZO DE 2025 ."
+      },
+      "descriptores": {
+        "descriptor": [
+          {
+            "elegido": {
+              "termino": "accidentes de trabajo"
+            },
+            "preferido": {
+              "termino": "Derecho laboral/accidentes de trabajo"
+            },
+            "sinonimos": {
+              "termino": [
+                "derecho del trabajo",
+                "accidentes y enfermedades de trabajo"
+              ]
+            }
+          },
+          {
+            "elegido": {
+              "termino": "enfermedad profesional"
+            },
+            "preferido": {
+              "termino": "Derecho laboral/accidentes de trabajo/enfermedad profesional"
+            },
+            "sinonimos": {
+              "termino": [
+                "derecho del trabajo",
+                "enfermedad laboral",
+                "accidentes y enfermedades de trabajo"
+              ]
+            }
+          },
+          {
+            "elegido": {
+              "termino": "asegurador por riesgos del trabajo"
+            },
+            "preferido": {
+              "termino": "Derecho laboral/accidentes de trabajo/riesgos del trabajo/seguro por accidente de trabajo/asegurador por riesgos del trabajo"
+            },
+            "sinonimos": {
+              "termino": [
+                "derecho del trabajo",
+                "aseguradora de riesgos del trabajo",
+                "ART",
+                "seguro de riesgos del trabajo",
+                "accidentes y enfermedades de trabajo",
+                "aseguradora de riesgos"
+              ]
+            }
+          },
+          {
+            "elegido": {
+              "termino": "FONDO PARA FINES ESPECÍFICOS"
+            },
+            "preferido": {
+              "termino": "FONDO PARA FINES ESPECÍFICOS"
+            },
+            "sinonimos": null
+          }
+        ],
+        "suggest": {
+          "termino": [
+            "accidentes de trabajo",
+            "seguro de riesgos del trabajo (seguro por accidente de trabajo)",
+            "enfermedad profesional",
+            "accidentes y enfermedades de trabajo (accidentes de trabajo)",
+            "asegurador por riesgos del trabajo",
+            "ART (asegurador por riesgos del trabajo)",
+            "riesgos del trabajo",
+            "derecho del trabajo (Derecho laboral)",
+            "FONDO PARA FINES ESPECÍFICOS",
+            "enfermedad laboral (enfermedad profesional)",
+            "Derecho laboral",
+            "aseguradora de riesgos del trabajo (asegurador por riesgos del trabajo)",
+            "aseguradora de riesgos (asegurador por riesgos del trabajo)",
+            "seguro por accidente de trabajo"
+          ]
+        }
+      },
+      "visto": {
+        "referencias-normativas": {
+          "referencia-normativa": [
+            {
+              "cr": null,
+              "id": "REFERENCIAS_NORMATIVAS_0",
+              "ref": "LEY C 024241 1993 09 23 0000 000 0000 000"
+            },
+            {
+              "cr": null,
+              "id": "REFERENCIAS_NORMATIVAS_1",
+              "ref": "LEY C 024557 1995 09 13 0000 000 0000 000"
+            },
+            {
+              "cr": null,
+              "id": "REFERENCIAS_NORMATIVAS_2",
+              "ref": "DEC C 000170 1996 02 21 0000 000 0000 000"
+            },
+            {
+              "cr": null,
+              "id": "REFERENCIAS_NORMATIVAS_3",
+              "ref": "DEC C 000659 1996 06 24 0000 000 0000 000"
+            },
+            {
+              "cr": null,
+              "id": "REFERENCIAS_NORMATIVAS_4",
+              "ref": "DEC C 000717 1996 06 28 0000 000 0000 000"
+            },
+            {
+              "cr": null,
+              "id": "REFERENCIAS_NORMATIVAS_5",
+              "ref": "DEC C 001338 1996 11 25 0000 000 0000 000"
+            }
+          ]
+        },
+        "texto": "el Expediente del Registro de la Superintendencia de Riesgos del Trabajo SRT N. 0235/97 dependiente del MINISTERIO DE TRABAJO Y SEGURIDAD SOCIAL, las Leyes N. 24.241, N. 24.557 y los Decretos N.\n\n170 de fecha 21 de febrero de 1996, N. 659 de fecha 24 de junio de 1996, el N. 717 del 28 de junio de 1996 y el Decreto N. 1.338 de fecha 25 de noviembre de 1996, y"
+      },
+      "considerando": {
+        "referencias-normativas": {
+          "referencia-normativa": [
+            {
+              "cr": null,
+              "id": "REFERENCIAS_NORMATIVAS_0",
+              "ref": "LEY C 024557 1995 09 13 0000 000 0000 000"
+            },
+            {
+              "cr": null,
+              "id": "REFERENCIAS_NORMATIVAS_1",
+              "ref": "LEY C 024557 1995 09 13 0049 000 0000 000"
+            },
+            {
+              "cr": null,
+              "id": "REFERENCIAS_NORMATIVAS_2",
+              "ref": "DEC C 000170 1996 02 21 0015 000 0000 000"
+            },
+            {
+              "cr": null,
+              "id": "REFERENCIAS_NORMATIVAS_3",
+              "ref": "DEC C 000659 1996 06 24 0000 000 0000 000"
+            }
+          ]
+        },
+        "sancion": "EL PRESIDENTE DE LA NACION ARGENTINA DECRETA:",
+        "texto": "Que la Ley N. 24.557 sobre Riesgos del Trabajo (L.R.T.) establece que las prestaciones correspondientes a las enfermedades laborales incluidas en el listado aprobado estarán a cargo de las ASEGURADORAS DE RIESGOS DEL TRABAJO (A.R.T.) y Compañías de Seguros previstas en el artículo 49 disposición adicional 4 de la misma Ley a la que el empleador se encuentre afiliado, a menos que el empleador hubiere optado por el régimen de autoseguro o que la relación laboral con el damnificado se hubiere extinguido con anterioridad a la afiliación del empleador a la Aseguradora.\n\nQue la información disponible, señala la existencia de un conjunto de enfermedades profesionales que conforman un pasivo oculto en el sistema productivo argentino.\n\nQue existen enfermedades de baja frecuencia pero de gravedad significativa y otras de menor gravedad pero de alta frecuencia y masividad.\n\nQue desde el punto de vista económico, las segundas resultan las de mayor impacto sobre el sistema.\n\nQue de ellas se destacan, las enfermedades profesionales del tipo hipoacusias perceptivas provocadas por exposición a los agentes de riesgo establecidos en el listado de enfermedades profesionales y demás instrumentos establecidos a través de la reglamentación de la L.R.T.\n\nQue las investigaciones y los estudios realizados señalan, también, que las hipoacusias perceptivas con las características indicadas en el párrafo precedente podrían implicar prestaciones dinerarias por montos muy significativos en relación a la recaudación total del sistema, aumentando, consecuentemente, las posibilidades de que se generen situaciones conflictivas.\n\nQue además la transición entre el antiguo régimen y el nuevo sistema no deben afectar el principio prioritario de garantizar a los trabajadores las prestaciones previstas en la L.R.T. en tiempo y forma, sin que ello produzca un aumento substantivo de los costos laborales para los empleadores.\n\nQue, tal como lo muestra la experiencia internacional, resulta recomendable crear un fondo especial a través del cual se garanticen los recursos para hacer frente a las prestaciones dinerarias que deben percibir los trabajadores en virtud de riesgos del trabajo.\n\nQue las estimaciones efectuadas, a partir de las actividades en donde los trabajadores se encuentran expuestos a los riesgos establecidos por la normativa de la L.R.T., y aplicando las estimaciones de los pagos por incapacidad resultantes de los instrumentos establecidos en el Decreto N. 659/96, permiten cuantificar que el monto estimado que como mínimo deberían integrar las aseguradoras a un fondo de fines específicos resultaría de una magnitud de PESOS SESENTA CENTAVOS ($ 0,60) mensuales.\n\nQue el artículo 15 del Decreto N. 170/96 establece que las alícuotas deberán incluir indicadores de siniestralidad presunta, que para este caso en particular devendría en siniestralidad presunta de hipocausias, que según las estimaciones preliminares serían de una magnitud mínima estimada en PESOS SESENTA CENTAVOS ($0,60) mensuales por trabajador incluido en el plantel del empleador afiliado.\n\nQue razones operativas, hacen recomendable que los exámenes para la detección de las hipoacusias se desarrollen en un período que permita garantizar a los trabajadores el adecuado cumplimiento de los mismos, manteniendo los criterios de inmediatez y objetividad en la evaluación de las incapacidades.\n\nQue la presente medida se dicta en uso de las facultades conferidas por el artículo 99, inciso 2, de la CONSTITUCION NACIONAL.\n\nPor ello,"
+      },
+      "articulo": [
+        {
+          "referencias-normativas": {
+            "referencia-normativa": {
+              "cr": null,
+              "id": "REFERENCIAS_NORMATIVAS_0",
+              "ref": "LEY C 024557 1995 09 13 0000 000 0000 000"
+            }
+          },
+          "numero-articulo": 1,
+          "texto": "*Art. 1: FONDO FIDUCIARIO DE ENFERMEDADES PROFESIONALES.\n\nCréase un fondo consolidado provisional que se denominará FONDO FIDUCIARIO DE ENFERMEDADES PROFESIONALES que deberán administrar las Aseguradoras de Riesgos del Trabajo, conforme lo establezca la reglamentación, y que servirá como herramienta para asistir al correcto funcionamiento del sistema de prestaciones previsto en la Ley N. 24.557.",
+          "modificado-por": {
+            "referencia-normativa": {
+              "cr": "(B.O. 03/01/2001) Artículo sustituido.",
+              "id": "MODIFICADO_POR_0",
+              "ref": "DNU C 001278 2000 12 28 0001 000 0000 000"
+            }
+          }
+        },
+        {
+          "referencias-normativas": {
+            "referencia-normativa": {
+              "cr": null,
+              "id": "REFERENCIAS_NORMATIVAS_0",
+              "ref": "LEY C 024557 1995 09 13 0006 000 0000 000"
+            }
+          },
+          "numero-articulo": 2,
+          "texto": "*Art. 2: APLICACION.\n\nTransitoriamente y hasta tanto se disponga lo contrario, el Fondo Fiduciario de Enfermedades Profesionales tendrá los siguientes destinos:\n\na) abonar las prestaciones dinerarias correspondientes a hipoacusias perceptivas consideradas según lo estipulado en el artículo 6, apartado 2 a) de la Ley N. 24.557 y su normativa reglamentaria.\n\nb) el costo de las prestaciones otorgadas por enfermedades no incluidas en el listado previsto en el artículo 6, apartado 2 a) de la Ley N. 24.557, aunque reconocidas como de naturaleza profesional, conforme las disposiciones contenidas en el artículo 6, apartado 2 b) de la misma ley, hasta que resulten incluidas en el listado de enfermedades profesionales, se abonará exclusivamente con los recursos del Fondo creado por el presente Decreto.\n\nc) el costo de las prestaciones otorgadas por enfermedades que se incluyan a partir de la fecha de vigencia de la presente incorporación en el listado previsto en el artículo 6°, apartado 2 a) de la Ley Nº 24.557; en un CIENTO POR CIENTO (100%) el primer año y un CINCUENTA POR CIENTO (50%) el segundo año, a contar desde su inclusión en el Listado de Enfermedades Profesionales. A partir del tercer año, las prestaciones estarán íntegramente a cargo de las Aseguradoras de Riesgos del Trabajo.\n\nd) el pago de los intereses, amortizaciones y demás costos de administración correspondientes a la cancelación de las deudas contraídas con el objeto de financiar el pago de las prestaciones indicadas en los incisos anteriores, mediante el uso de fuentes de crédito a las que hubiere sido autorizado acceder, conforme las condiciones que establezca la Superintendencia de Seguros de la Nación, en su calidad de Autoridad de Aplicación.",
+          "modificado-por": {
+            "referencia-normativa": [
+              {
+                "cr": "(B.O. 20/01/2014) Inc. c) incorporado.",
+                "id": "MODIFICADO_POR_0",
+                "ref": "DEC C 000049 2014 01 14 0003 000 0000 000"
+              },
+              {
+                "cr": "(B.O. 03/01/2001) Artículo sustituido.",
+                "id": "MODIFICADO_POR_1",
+                "ref": "DNU C 001278 2000 12 28 0000 000 0000 000"
+              },
+              {
+                "cr": "(B.O. 18/02/2022) Inciso d) incorporado.",
+                "id": "MODIFICADO_POR_2",
+                "ref": "DEC C 000079 2022 02 17 0004 000 0000 000"
+              }
+            ]
+          }
+        },
+        {
+          "numero-articulo": 3,
+          "texto": "*Art. 3: UTILIZACION DEL FONDO.\n\nAl sólo efecto del pago de las prestaciones dinerarias correspondientes a hipoacusias perceptivas consideradas según lo estipulado en el artículo 6, apartado 2 a) de la Ley N.\n\n24.557 y su normativa reglamentaria, las aseguradoras podrán utilizar el Fondo Fiduciario de Enfermedades Profesionales en una proporción según la fecha en que se abone la prestación dineraria y que surgirá de aplicar el factor G que se detalla a continuación, sobre la base de la siguiente tabla.\n\n Período dentro del cual se abonó la G  prestación dineraria por hipoacusia Desde el 1/7/1996 al 30/6/1998 1  Desde el 1/7/1998 al 30/6/1999 0.95  Desde el 1/7/1999 al 30/6/2000 0.90  Desde el 1/7/2000 al 30/6/2001 0.85  Desde el 1/7/2001 al 30/6/2002 0.80  Desde el 1/7/2002 al 30/6/2003 0.75  Desde el 1/7/2003 al 30/6/2004 0.70  Desde el 1/7/2004 al 30/6/2005 0.65  Desde el 1/7/2005 al 30/6/2006 0.60  Desde el 1/7/2006 al 30/6/2007 0.55  Desde el 1/7/2007 al 30/6/2008 0.50  Desde el 1/7/2008 al 30/6/2009 0.45  Desde el 1/7/2009 al 30/6/2010 0.40  Desde el 1/7/2010 al 30/6/2011 0.35  Desde el 1/7/2011 al 30/6/2012 0.30  Desde el 1/7/2012 al 30/6/2013 0.25  Desde el 1/7/2013 al 30/6/2014 0.20  Desde el 1/7/2014 al 30/6/2015 0.15  Desde el 1/7/2015 al 30/6/2016 0.10  Desde el 1/7/2016 al 30/6/2017 0.05  Desde el 1/7/2017 en adelante 0.00",
+          "modificado-por": {
+            "referencia-normativa": {
+              "cr": "(B.O. 03/01/2001) Primer párrafo sustituido.",
+              "id": "MODIFICADO_POR_0",
+              "ref": "DNU C 001278 2000 12 28 0000 000 0000 000"
+            }
+          }
+        },
+        {
+          "numero-articulo": 4,
+          "texto": "*Art. 4: FINANCIAMIENTO. El Fondo Fiduciario de Enfermedades Profesionales se financiará con los siguientes recursos:\n\na) Una porción de cada alícuota de afiliación percibida en los contratos que se renueven, prorroguen o inicien con posterioridad a la fecha del presente Decreto.\n\nb) La rentabilidad que eventualmente pueda producir la inversión de los mencionados recursos.\n\nc) El saldo del Fondo para Fines Específicos creado por cada aseguradora de conformidad con lo dispuesto por el artículo 1 del presente Decreto en su redacción original (B.O. 4/7/97), que deberá ser transferido en el plazo que fije la autoridad de aplicación.\n\nd) Los derivados de operaciones de financiamiento realizadas a través de los instrumentos previstos en el Libro Tercero, Título IV, Capítulo 30 del CÓDIGO CIVIL Y COMERCIAL DE LA NACIÓN, incluida la emisión de títulos valores con o sin oferta pública.\n\ne) Los obtenidos mediante el acceso a operaciones de crédito.\n\nf) Otros ingresos, aportes, contribuciones, subsidios, legados o donaciones que específicamente se le destinen.\n\nEl acceso a las fuentes de financiamiento previstas en los incisos d) y e) precedentes solo podrá tener por objeto financiar el pago de las prestaciones indicadas en los incisos a), b) y c) del artículo 2° y requerirá de la previa intervención de la SUPERINTENDENCIA DE SEGUROS DE LA NACIÓN, en su carácter de Autoridad de Aplicación.",
+          "modificado-por": {
+            "referencia-normativa": [
+              {
+                "cr": "(B.O. 03/01/2001) Artículo sustituido.",
+                "id": "MODIFICADO_POR_0",
+                "ref": "DNU C 001278 2000 12 28 0000 000 0000 000"
+              },
+              {
+                "cr": "B.O. 18/02/2022) Incisos d), e), f) y último párrafo incorporados.",
+                "id": "MODIFICADO_POR_1",
+                "ref": "DEC C 000079 2022 02 17 0005 000 0000 000"
+              }
+            ]
+          }
+        },
+        {
+          "numero-articulo": 5,
+          "texto": "Art. 5: Agréguese a continuación del segundo párrafo del artículo 15 del Decreto Nº 170/96 lo siguiente:.\n\n\"Integrará también la alícuota, una suma fija por cada trabajador, de un valor mínimo de PESOS SESENTA CENTAVOS ($ 0,60), destinada al financiamiento del FONDO para FINES ESPECIFICOS\".",
+          "observado-por": {
+            "referencia-normativa": [
+              {
+                "cr": "(B.O. 10/03/2021) Por Resolución del Ministerio de Trabajo, Empleo y Seguridad Social se dispone que la suma fija a abonar por cada trabajador conjuntamente con la alícuota, establecida en el presente artículo con destino al Fondo Fiduciario de Enfermedades Profesionales (FFEP), será de un valor de ($ 40.-).",
+                "id": "OBSERVADO_POR_0",
+                "ref": "RES C 000115 2021 03 09 0001 000 0000 000"
+              },
+              {
+                "cr": "(B.O. 11/08/2021) Por Resolución del Ministerio de Trabajo, Empleo y Seguridad Social se establece que el valor de la suma fija prevista en el presente Artículo se incrementará trimestralmente según la variación de la Remuneración Imponible Promedio de los Trabajadores Estables (RIPTE) -Índice no decreciente-.",
+                "id": "OBSERVADO_POR_1",
+                "ref": "RES C 000467 2021 08 10 0000 000 0000 000"
+              },
+              {
+                "cr": "(B.O. 2/09/2021) Por Resolución de la Superintendencia de Riesgos del Trabajo se establece que el valor de la suma fija prevista en el presente Artículo será de ($ 45,07)para el devengado del mes de julio.",
+                "id": "OBSERVADO_POR_2",
+                "ref": "RES C 000047 2021 08 31 0001 000 0000 000"
+              },
+              {
+                "cr": "(B.O. 14/06/2022) Por Resolución del Ministerio de Trabajo, Empleo y Seguridad Social se establece que el valor de la suma fija prevista en el presente Artículo será de ($ 127,65))para las obligaciones con vencimiento a partir del mes de julio de 2022.",
+                "id": "OBSERVADO_POR_3",
+                "ref": "RES C 000649 2022 06 13 0001 000 0000 000"
+              },
+              {
+                "cr": "(B.O. 18/08/2022) Por Disposición de la Superintendencia de Riesgos del Trabajo- Gerencia de Control Prestacional se establece que el valor de la suma fija prevista en el presente artículo será de ($ 141) para el devengado del mes de agosto de 2022.",
+                "id": "OBSERVADO_POR_4",
+                "ref": "DIS C 000004 2022 08 17 0001 000 0000 000"
+              },
+              {
+                "cr": "(B.O. 27/12/2022) Por Disposición de la Superintendencia de Riesgos del Trabajo- Gerencia de Control Prestacional se establece que el valor de la suma fija prevista en el presente artículo será de ($ 173) para el devengado del mes de diciembre de 2022.",
+                "id": "OBSERVADO_POR_5",
+                "ref": "DIS C 000008 2022 12 22 0001 000 0000 000"
+              },
+              {
+                "cr": "(B.O. 20/01/2023) Por Disposición de la Superintendencia de Riesgos del Trabajo Gerencia de Control Prestacional se establece que el valor de la suma fija prevista en el presente artículo será de ($ 183) para el devengado del mes de Enero de 2023.",
+                "id": "OBSERVADO_POR_6",
+                "ref": "DIS C 000001 2023 01 18 0001 000 0000 000"
+              },
+              {
+                "cr": "(B.O. 12/5/2023) POR RESOLUCION DE LA SUPERINTENDENCIA DE RIESGOS DEL TRABAJO GERENCIA DE CONTROL PRESTACIONAL SE ESTABLECE EL VALOR DE LA SUMA FIJA EN ($238) PARA EL MES DE MAYO.",
+                "id": "OBSERVADO_POR_7",
+                "ref": "DIS C 000005 2023 05 10 0000 000 0000 000"
+              },
+              {
+                "cr": "(B.O. 21/06/2023) Por Disposición de la Superintendencia de Riesgos del Trabajo Gerencia de Control Prestacional se establece que el valor de la suma fija prevista en el presente artículo será de ($ 262) para el devengado del mes de junio de 2023.",
+                "id": "OBSERVADO_POR_8",
+                "ref": "DIS C 000006 2023 06 15 0001 000 0000 000"
+              },
+              {
+                "cr": "(B.O. 14/08/2023) Por Disposición de la Superintendencia de Riesgos del Trabajo Gerencia de Control Prestacional se establece que el valor de la suma fija prevista en el presente artículo será de ($ 301) para el devengado del mes de Agosto de 2023.",
+                "id": "OBSERVADO_POR_9",
+                "ref": "DIS C 000008 2023 08 10 0001 000 0000 000"
+              },
+              {
+                "cr": "(B.O. 15/12/2023) Por Disposición de la Superintendencia de Riesgos del Trabajo Gerencia de Control Prestacional se establece que el valor de la suma fija prevista en el presente artículo será de ($418)) para el devengado del mes de Diciembre de 2023.",
+                "id": "OBSERVADO_POR_10",
+                "ref": "DIS C 000012 2023 12 14 0001 000 0000 000"
+              }
+            ]
+          }
+        },
+        {
+          "referencias-normativas": {
+            "referencia-normativa": {
+              "cr": null,
+              "id": "REFERENCIAS_NORMATIVAS_0",
+              "ref": "DEC C 000170 1996 02 21 0015 000 0000 000"
+            }
+          },
+          "numero-articulo": 6,
+          "texto": "Art. 6: La integración a las alícuotas pactadas de una suma de PESOS SESENTA CENTAVOS ($ 0,60) por cada trabajador del empleador afiliado, con destino al FONDO para FINES ESPECIFICOS, no podrá ser considerada, en modo alguno, a los efectos de la aplicación de las disposiciones contenidas en el cuarto, quinto y sexto párrafo del artículo 15 del Decreto N. 170/96."
+        },
+        {
+          "numero-articulo": 7,
+          "texto": "Art. 7: AUTORIDAD DE APLICACION.\n\nLa S.S.N. será la autoridad de aplicación del presente en los aspectos relativos a la administración de los recursos del FONDO para FINES ESPECIFICOS, y la SUPERINTENDENCIA DE RIESGOS DEL TRABAJO (S.R.T.) lo será respecto a la aplicación y utilización de dichos recursos. Por Resolución Conjunta de ambos organismos, se reglamentará la metodología para determinar los excedentes del FONDO para FINES ESPECIFICOS."
+        },
+        {
+          "numero-articulo": 8,
+          "texto": "Art. 8: COMITE DE SEGUIMIENTO.\n\nEl Comité Consultivo Permanente será el encargado de monitorear el adecuado cumplimiento de los objetivos del FONDO para FINES ESPECIFICOS. A tales fines podrá proponer la inclusión de otras enfermedades profesionales de las establecidas en la Lista de Enfermedades Profesionales, el destino de los excedentes a otros fines, y la reducción o eliminación del fondo creado por el presente Decreto en el caso de que resultase excedentario de manera recurrente."
+        },
+        {
+          "derogado-por": {
+            "referencia-normativa": {
+              "cr": "(B.O. 03/01/2001) Artículo derogado.",
+              "id": "DEROGADO_POR_0",
+              "ref": "DNU C 001278 2000 12 28 0018 000 0000 000"
+            }
+          },
+          "numero-articulo": 9,
+          "texto": "Art. 9: Nota de Redacción: Derogado por art. 18 del Decreto 1.278/2000."
+        },
+        {
+          "numero-articulo": 10,
+          "texto": "Art. 10: Comuníquese, publíquese, dése a la Dirección Nacional del Registro Oficial y archívese."
+        }
+      ],
+      "firmantes": {
+        "firmantes": "FIRMANTES"
+      },
+      "id-infojus": "DN19970000590",
+      "fecha-umod": 20250326134611
+    }
+  }
+}

--- a/src/Tests/Argentina/SaijSamples/Diff/123456789-0abc-766-1000-2102soterced-new.json
+++ b/src/Tests/Argentina/SaijSamples/Diff/123456789-0abc-766-1000-2102soterced-new.json
@@ -1,0 +1,277 @@
+{
+  "document": {
+    "metadata": {
+      "uuid": "123456789-0abc-766-1000-2102soterced",
+      "document-content-type": "legislacion",
+      "timestamp": 1743087141769,
+      "operation": "ADD",
+      "target-document-repository-id": "infojus",
+      "target-index-id": "index",
+      "target-document-indexing-id": "legislacion",
+      "document-recovery-strategy": "abstract-legislacion",
+      "friendly-url": {
+        "subdomain": "decreto necesidad urgencia",
+        "description": "1667-nacional-decreto-necesidad-urgencia-sobre-asignaciones-familiares-dn20120001667-2012-09-12"
+      }
+    },
+    "content": {
+      "mecanografico": 20120001667,
+      "jurisdiccion": {
+        "codigo": "C",
+        "descripcion": "Nacional",
+        "capital": "Capital Federal",
+        "id-pais": 11
+      },
+      "numero-norma": 1667,
+      "tipo-norma": {
+        "codigo": "DNU",
+        "texto": "Decreto de Necesidad y Urgencia"
+      },
+      "fecha": "2012-09-12",
+      "standard-normativo": "DNU C 001667 2012 09 12",
+      "titulo-norma": "DECRETO DE NECESIDAD Y URGENCIA SOBRE ASIGNACIONES FAMILIARES",
+      "publicacion-codificada": {
+        "publicacion-decodificada": {
+          "organismo": "Boletín Oficial",
+          "fecha": "2012 09 13"
+        }
+      },
+      "lugar-emision": "BUENOS AIRES",
+      "nombre-coloquial": "DECRETO NACIONAL 1.667/2012",
+      "estado": "Vigente, de alcance general",
+      "uid-alta": "ABM",
+      "uid-mod": "ABM",
+      "fecha-alta": "2025-03-27",
+      "fecha-mod": "2025-03-27",
+      "timestamp": "2025-03-27T11:26:46",
+      "timestamp-alta": "2025-03-27T11:26:46",
+      "timestamp-m": "2025-03-27T11:26:46",
+      "generalidades": {
+        "sintesis": "Se establecen requisitos para el acceso a las prestaciones establecidas mediante la Ley N° 24.714.",
+        "informacion-vinculada": 1E+19,
+        "observaciones-generales": "CANTIDAD DE ARTICULOS QUE COMPONEN LA NORMA: 6 .\n\nNRO. DE ART. QUE ESTABLECE LA ENTRADA EN VIGENCIA: 4.\n\nOBSERVACION: Se declara la validez del presente decreto por art. 1 de la Resolución S/N de la Cámara de Diputados de la Nación de fecha 21/11/2012 (B.O. 6/12/2012)conforme a lo establecido en los arts. 1, 22 y 26 de la ley 26.122."
+      },
+      "descriptores": {
+        "descriptor": [
+          {
+            "elegido": {
+              "termino": "decreto de necesidad y urgencia"
+            },
+            "preferido": {
+              "termino": "Derecho administrativo/acto administrativo/acto administrativo de alcance general/reglamentos/decreto de necesidad y urgencia"
+            },
+            "sinonimos": {
+              "termino": [
+                "reglamento de necesidad y urgencia",
+                "actos de alcance general",
+                "reglamento administrativo"
+              ]
+            }
+          },
+          {
+            "elegido": {
+              "termino": "asignaciones familiares"
+            },
+            "preferido": {
+              "termino": "Seguridad social/Sistema único de la seguridad social/subsidios de la Seguridad Social/asignaciones familiares"
+            },
+            "sinonimos": {
+              "termino": [
+                "salario familiar",
+                "asistencia familiar",
+                "subsidio familiar",
+                "adicional por cargas de familia",
+                "SUSS"
+              ]
+            }
+          }
+        ],
+        "suggest": {
+          "termino": [
+            "salario familiar (asignaciones familiares)",
+            "asistencia familiar (asignaciones familiares)",
+            "Sistema único de la seguridad social",
+            "subsidios de la Seguridad Social",
+            "Seguridad social",
+            "reglamentos",
+            "reglamento de necesidad y urgencia (decreto de necesidad y urgencia)",
+            "asignaciones familiares",
+            "acto administrativo",
+            "subsidio familiar (asignaciones familiares)",
+            "SUSS (Sistema único de la seguridad social)",
+            "acto administrativo de alcance general",
+            "actos de alcance general (acto administrativo de alcance general)",
+            "decreto de necesidad y urgencia",
+            "reglamento administrativo (reglamentos)",
+            "Derecho administrativo",
+            "adicional por cargas de familia (asignaciones familiares)"
+          ]
+        }
+      },
+      "visto": {
+        "referencias-normativas": {
+          "referencia-normativa": [
+            {
+              "cr": null,
+              "id": "REFERENCIAS_NORMATIVAS_0",
+              "ref": "LEY C 024013 1991 11 13 0000 000 0000 000"
+            },
+            {
+              "cr": null,
+              "id": "REFERENCIAS_NORMATIVAS_1",
+              "ref": "LEY C 024241 1993 09 23 0000 000 0000 000"
+            },
+            {
+              "cr": null,
+              "id": "REFERENCIAS_NORMATIVAS_2",
+              "ref": "LEY C 024557 1995 09 13 0000 000 0000 000"
+            },
+            {
+              "cr": null,
+              "id": "REFERENCIAS_NORMATIVAS_3",
+              "ref": "LEY C 025191 1999 11 03 0000 000 0000 000"
+            },
+            {
+              "cr": null,
+              "id": "REFERENCIAS_NORMATIVAS_4",
+              "ref": "LEY C 026122 2006 07 20 0000 000 0000 000"
+            },
+            {
+              "cr": null,
+              "id": "REFERENCIAS_NORMATIVAS_5",
+              "ref": "DEC C 001245 1996 11 01 0000 000 0000 000"
+            },
+            {
+              "cr": null,
+              "id": "REFERENCIAS_NORMATIVAS_6",
+              "ref": "DNU C 001602 2009 10 29 0000 000 0000 000"
+            },
+            {
+              "cr": null,
+              "id": "REFERENCIAS_NORMATIVAS_7",
+              "ref": "DNU C 000446 2011 04 18 0000 000 0000 000"
+            }
+          ]
+        },
+        "texto": "las Leyes Nº 24.013, 24.241, 24.557, 24.714, 25.191 y sus modificatorias y 26.122, los Decretos Nros. 1.245 de fecha 1° de noviembre de 1996 y sus modificatorios, 1.602 de fecha 29 de octubre de 2009, y 446 de fecha 18 de abril de 2011, y"
+      },
+      "considerando": {
+        "referencias-normativas": {
+          "referencia-normativa": [
+            {
+              "cr": null,
+              "id": "REFERENCIAS_NORMATIVAS_0",
+              "ref": "LEY C 026122 2006 07 20 0000 000 0000 000"
+            },
+            {
+              "cr": null,
+              "id": "REFERENCIAS_NORMATIVAS_1",
+              "ref": "LEY C 024714 1996 10 02 0000 000 0000 000"
+            },
+            {
+              "cr": null,
+              "id": "REFERENCIAS_NORMATIVAS_2",
+              "ref": "CON C 000000 1994 08 22 0099 000 0000 000"
+            },
+            {
+              "cr": null,
+              "id": "REFERENCIAS_NORMATIVAS_3",
+              "ref": "LEY C 026122 2006 07 20 0002 000 0000 000"
+            },
+            {
+              "cr": null,
+              "id": "REFERENCIAS_NORMATIVAS_4",
+              "ref": "LEY C 026122 2006 07 20 0019 000 0020 000"
+            }
+          ]
+        },
+        "sancion": "LA PRESIDENTA DE LA NACION ARGENTINA EN ACUERDO GENERAL DE MINISTROS DECRETA:",
+        "texto": "Que a través de la Ley Nº 24.714 se instituyó con alcance nacional y obligatorio el Régimen de Asignaciones Familiares.\n\nQue dicha norma alcanza a los trabajadores que prestan servicios remunerados en relación de dependencia en la actividad privada, a los beneficiarios de la Prestación por Desempleo, de la Ley de Riesgos del Trabajo, del Sistema Integrado Previsional Argentino (SIPA) y de pensiones no contributivas por invalidez, como así también a los grupos familiares que se encuentren desocupados o que se desempeñen en la economía informal.\n\nQue resulta adecuada la adopción de políticas públicas que permitan mejorar la situación de los ámbitos más desprotegidos de la sociedad de manera simultánea con el crecimiento económico.\n\nQue el sistema de seguridad social es la principal herramienta de redistribución de los recursos, brindando cobertura a las contingencias sociales y protegiendo a los más necesitados.\n\nQue en este contexto debe priorizarse el análisis de la situación de cada grupo familiar.\n\nQue la familia es la célula básica de todas las sociedades y su protección genera mejores condiciones para la misma en su conjunto.\n\nQue es necesario concentrar la cobertura de las contingencias en el grupo familiar y, de esa manera, lograr una mejor redistribución del ingreso; focalizando las políticas públicas sobre aquellos sectores sociales que requieren atención prioritaria.\n\nQue en virtud de ello y con el ánimo de mejorar las condiciones de la población resulta necesario considerar, para el acceso a las prestaciones de la Ley Nº 24.714, los ingresos del grupo familiar en su conjunto.\n\nQue a través de esta modificación se contribuye a optimizar la administración de los recursos de la seguridad social, en un marco de equidad que permite otorgar las prestaciones a los sectores de la población que resultan de atención prioritaria.\n\nQue la particular naturaleza de la situación planteada y la urgencia requerida para su resolución, dificultan seguir los trámites ordinarios previstos por la CONSTITUCION NACIONAL para la sanción de las leyes, por lo que el PODER EJECUTIVO NACIONAL adopta la presente medida con carácter excepcional.\n\nQue la Ley Nº 26.122, regula el trámite y los alcances de la intervención del HONORABLE CONGRESO DE LA NACION respecto de los Decretos de Necesidad y Urgencia dictados por el PODER EJECUTIVO NACIONAL, en virtud de lo dispuesto por el artículo 99 inciso 3 de la CONSTITUCION NACIONAL. Que la citada ley determina, que la Comisión Bicameral Permanente tiene competencia para pronunciarse respecto de la validez o invalidez de los decretos de necesidad y urgencia, así como elevar el dictamen al plenario de cada Cámara para su expreso tratamiento, en el plazo de DIEZ (10) días hábiles.\n\nQue el artículo 20 de la Ley Nº 26.122 prevé incluso que, en el supuesto que la Comisión Bicameral Permanente no eleve el correspondiente despacho, las Cámaras se abocarán al expreso e inmediato tratamiento del decreto, de conformidad con lo establecido en los artículos 99, inciso 3 y 82 de la CONSTITUCION NACIONAL.\n\nQue, por su parte, el artículo 22 de la misma ley dispone que las Cámaras se pronuncien mediante sendas resoluciones y que el rechazo o aprobación de los decretos deberá ser expreso conforme lo establecido en el artículo 82 de la Carta Magna.\n\nQue ha tomado la intervención de su competencia el servicio jurídico permanente.\n\nQue la presente medida se dicta en uso de las facultades que otorga el artículo 99, inciso 3, de la CONSTITUCION NACIONAL y de los artículos 2°, 19 y 20 de la Ley Nº 26.122. Por ello,"
+      },
+      "articulo": [
+        {
+          "numero-articulo": 1,
+          "texto": "Artículo 1° - Los límites que condicionan el otorgamiento de las asignaciones familiares o la cuantía de las mismas, se calcularán en función de la totalidad de los ingresos correspondientes al grupo familiar.",
+          "observado-por": {
+            "referencia-normativa": [
+              {
+                "cr": "(B.O. 31/05/2013) SE ESTABLECE EL LIMITE DE INGRESOS MINIMO Y MAXIMO CORRESPONDIENTES AL GRUPO FAMILIAR EN PESOS DOSCIENTOS ($ 200.-) Y PESOS DIECISEIS MIL OCHOCIENTOS ($ 16.800.-) RESPSECTIVAMENTE",
+                "id": "OBSERVADO_POR_0",
+                "ref": "DEC C 000614 2013 05 30 0001 000 0000 000"
+              },
+              {
+                "cr": "(B.O. 17/3/2016) SE ESTABLECE El LIMITE DE INGRESOS MINIMO Y MAXIMO CORRESPONDIENTES AL GRUPO FAMILIAR EN PESOS DOSCIENTOS ($ 200.-) y PESOS SESENTA MIL ($60.000) RESPECTIVAMENTE",
+                "id": "OBSERVADO_POR_1",
+                "ref": "DEC C 000492 2016 03 16 0001 000 0000 000"
+              },
+              {
+                "cr": "(B.O. 27/9/2024) La percepción de un ingreso superior a ($1.799.733) por parte de una de las personas integrantes del grupo familiar excluye a dicho grupo del cobro de las asignaciones familiares, aun cuando la suma de sus ingresos no supere el límite máximo de ingresos establecido en los anexos de la presente por Resolución de la Anses",
+                "id": "OBSERVADO_POR_2",
+                "ref": "RES C 000840 2024 09 25 0001 000 0000 000"
+              },
+              {
+                "cr": "(B.O. 27/3/2025) La percepción de un ingreso superior a ($2.105.438) por parte de una de las personas integrantes del grupo familiar excluye a dicho grupo del cobro de las asignaciones familiares, aun cuando la suma de sus ingresos no supere el límite máximo de ingresos establecido en los anexos de la presente por Resolución de la Anses",
+                "id": "OBSERVADO_POR_3",
+                "ref": "RES C 000186 2025 03 26 0004 000 0000 000"
+              }
+            ]
+          }
+        },
+        {
+          "referencias-normativas": {
+            "referencia-normativa": [
+              {
+                "cr": null,
+                "id": "REFERENCIAS_NORMATIVAS_0",
+                "ref": "LEY C 024013 1991 11 13 0000 000 0000 000"
+              },
+              {
+                "cr": null,
+                "id": "REFERENCIAS_NORMATIVAS_1",
+                "ref": "LEY C 024241 1993 09 23 0000 000 0000 000"
+              },
+              {
+                "cr": null,
+                "id": "REFERENCIAS_NORMATIVAS_2",
+                "ref": "LEY C 024557 1995 09 13 0000 000 0000 000"
+              },
+              {
+                "cr": null,
+                "id": "REFERENCIAS_NORMATIVAS_3",
+                "ref": "LEY C 024714 1996 10 02 0000 000 0000 000"
+              },
+              {
+                "cr": null,
+                "id": "REFERENCIAS_NORMATIVAS_4",
+                "ref": "LEY C 025191 1999 11 03 0000 000 0000 000"
+              }
+            ]
+          },
+          "numero-articulo": 2,
+          "texto": "Art. 2° - A los efectos de la aplicación del artículo 1° del presente Decreto, deben considerarse como ingresos, las remuneraciones de los trabajadores en relación de dependencia registrados, las rentas de referencia para trabajadores autónomos y monotributistas, las sumas originadas en Prestaciones Contributivas y/o No Contributivas Nacionales, Provinciales, Municipales o de la Ciudad Autónoma de Buenos Aires, incluyendo las prestaciones previstas en las Leyes Nros. 24.013, 24.241, 24.557, Nº 24.714 artículo 11, 25.191 y sus respectivas modificatorias y complementarias."
+        },
+        {
+          "numero-articulo": 3,
+          "texto": "Art. 3° - Facúltase a la ADMINISTRACION NACIONAL DE LA SEGURIDAD SOCIAL (ANSES) para que dicte las normas aclaratorias y complementarias necesarias para la implementación del presente decreto."
+        },
+        {
+          "numero-articulo": 4,
+          "texto": "Art. 4° - El presente decreto comenzará a regir a partir de las asignaciones familiares devengadas por el mes de septiembre de 2012."
+        },
+        {
+          "numero-articulo": 5,
+          "texto": "Art. 5° - Dése cuenta a la Comisión Bicameral Permanente del HONORABLE CONGRESO DE LA NACION."
+        },
+        {
+          "numero-articulo": 6,
+          "texto": "Art. 6° - Comuníquese, publíquese, dése a la Dirección Nacional del Registro Oficial y archívese."
+        }
+      ],
+      "firmantes": {
+        "firmantes": "FERNANDEZ DE KIRCHNER-Abal Medina-Randazzo-Garré-Lorenzino-Alak-Tomada-Kirchner-Manzur-Sileoni-Barañao-Meyer-Puricelli n - a a"
+      },
+      "id-infojus": "DN20120001667",
+      "fecha-umod": 20250327115221
+    }
+  }
+}

--- a/src/Tests/Argentina/SaijSamples/Diff/123456789-0abc-766-1000-2102soterced-old.json
+++ b/src/Tests/Argentina/SaijSamples/Diff/123456789-0abc-766-1000-2102soterced-old.json
@@ -1,0 +1,272 @@
+{
+  "document": {
+    "metadata": {
+      "uuid": "123456789-0abc-766-1000-2102soterced",
+      "document-content-type": "legislacion",
+      "timestamp": 1727459063066,
+      "operation": "ADD",
+      "target-document-repository-id": "infojus",
+      "target-index-id": "index",
+      "target-document-indexing-id": "legislacion",
+      "document-recovery-strategy": "abstract-legislacion",
+      "friendly-url": {
+        "subdomain": "decreto necesidad urgencia",
+        "description": "1667-nacional-decreto-necesidad-urgencia-sobre-asignaciones-familiares-dn20120001667-2012-09-12"
+      }
+    },
+    "content": {
+      "mecanografico": 20120001667,
+      "jurisdiccion": {
+        "codigo": "C",
+        "descripcion": "Nacional",
+        "capital": "Capital Federal",
+        "id-pais": 11
+      },
+      "numero-norma": 1667,
+      "tipo-norma": {
+        "codigo": "DNU",
+        "texto": "Decreto de Necesidad y Urgencia"
+      },
+      "fecha": "2012-09-12",
+      "standard-normativo": "DNU C 001667 2012 09 12",
+      "titulo-norma": "DECRETO DE NECESIDAD Y URGENCIA SOBRE ASIGNACIONES FAMILIARES",
+      "publicacion-codificada": {
+        "publicacion-decodificada": {
+          "organismo": "Boletín Oficial",
+          "fecha": "2012 09 13"
+        }
+      },
+      "lugar-emision": "BUENOS AIRES",
+      "nombre-coloquial": "DECRETO NACIONAL 1.667/2012",
+      "estado": "Vigente, de alcance general",
+      "uid-alta": "ABM",
+      "uid-mod": "ABM",
+      "fecha-alta": "2024-09-27",
+      "fecha-mod": "2024-09-27",
+      "timestamp": "2024-09-27T14:32:42",
+      "timestamp-alta": "2024-09-27T14:32:42",
+      "timestamp-m": "2024-09-27T14:32:42",
+      "generalidades": {
+        "sintesis": "Se establecen requisitos para el acceso a las prestaciones establecidas mediante la Ley N° 24.714.",
+        "informacion-vinculada": 1E+19,
+        "observaciones-generales": "CANTIDAD DE ARTICULOS QUE COMPONEN LA NORMA: 6 NRO. DE ART. QUE ESTABLECE LA ENTRADA EN VIGENCIA: 4 OBSERVACION: Se declara la validez del presente decreto por art. 1 de la Resolución S/N de la Cámara de Diputados de la Nación de fecha 21/11/2012 (B.O. 6/12/2012)conforme a lo establecido en los arts. 1, 22 y 26 de la ley 26.122"
+      },
+      "descriptores": {
+        "descriptor": [
+          {
+            "elegido": {
+              "termino": "decreto de necesidad y urgencia"
+            },
+            "preferido": {
+              "termino": "Derecho administrativo/acto administrativo/acto administrativo de alcance general/reglamentos/decreto de necesidad y urgencia"
+            },
+            "sinonimos": {
+              "termino": [
+                "reglamento de necesidad y urgencia",
+                "actos de alcance general",
+                "reglamento administrativo"
+              ]
+            }
+          },
+          {
+            "elegido": {
+              "termino": "asignaciones familiares"
+            },
+            "preferido": {
+              "termino": "Seguridad social/Sistema único de la seguridad social/subsidios de la Seguridad Social/asignaciones familiares"
+            },
+            "sinonimos": {
+              "termino": [
+                "salario familiar",
+                "asistencia familiar",
+                "subsidio familiar",
+                "adicional por cargas de familia",
+                "SUSS"
+              ]
+            }
+          }
+        ],
+        "suggest": {
+          "termino": [
+            "salario familiar (asignaciones familiares)",
+            "asistencia familiar (asignaciones familiares)",
+            "Sistema único de la seguridad social",
+            "subsidios de la Seguridad Social",
+            "Seguridad social",
+            "reglamentos",
+            "reglamento de necesidad y urgencia (decreto de necesidad y urgencia)",
+            "asignaciones familiares",
+            "acto administrativo",
+            "subsidio familiar (asignaciones familiares)",
+            "SUSS (Sistema único de la seguridad social)",
+            "acto administrativo de alcance general",
+            "actos de alcance general (acto administrativo de alcance general)",
+            "decreto de necesidad y urgencia",
+            "reglamento administrativo (reglamentos)",
+            "Derecho administrativo",
+            "adicional por cargas de familia (asignaciones familiares)"
+          ]
+        }
+      },
+      "visto": {
+        "referencias-normativas": {
+          "referencia-normativa": [
+            {
+              "cr": null,
+              "id": "REFERENCIAS_NORMATIVAS_0",
+              "ref": "LEY C 024013 1991 11 13 0000 000 0000 000"
+            },
+            {
+              "cr": null,
+              "id": "REFERENCIAS_NORMATIVAS_1",
+              "ref": "LEY C 024241 1993 09 23 0000 000 0000 000"
+            },
+            {
+              "cr": null,
+              "id": "REFERENCIAS_NORMATIVAS_2",
+              "ref": "LEY C 024557 1995 09 13 0000 000 0000 000"
+            },
+            {
+              "cr": null,
+              "id": "REFERENCIAS_NORMATIVAS_3",
+              "ref": "LEY C 025191 1999 11 03 0000 000 0000 000"
+            },
+            {
+              "cr": null,
+              "id": "REFERENCIAS_NORMATIVAS_4",
+              "ref": "LEY C 026122 2006 07 20 0000 000 0000 000"
+            },
+            {
+              "cr": null,
+              "id": "REFERENCIAS_NORMATIVAS_5",
+              "ref": "DEC C 001245 1996 11 01 0000 000 0000 000"
+            },
+            {
+              "cr": null,
+              "id": "REFERENCIAS_NORMATIVAS_6",
+              "ref": "DNU C 001602 2009 10 29 0000 000 0000 000"
+            },
+            {
+              "cr": null,
+              "id": "REFERENCIAS_NORMATIVAS_7",
+              "ref": "DNU C 000446 2011 04 18 0000 000 0000 000"
+            }
+          ]
+        },
+        "texto": "las Leyes Nº 24.013, 24.241, 24.557, 24.714, 25.191 y sus modificatorias y 26.122, los Decretos Nros. 1.245 de fecha 1° de noviembre de 1996 y sus modificatorios, 1.602 de fecha 29 de octubre de 2009, y 446 de fecha 18 de abril de 2011, y"
+      },
+      "considerando": {
+        "referencias-normativas": {
+          "referencia-normativa": [
+            {
+              "cr": null,
+              "id": "REFERENCIAS_NORMATIVAS_0",
+              "ref": "LEY C 026122 2006 07 20 0000 000 0000 000"
+            },
+            {
+              "cr": null,
+              "id": "REFERENCIAS_NORMATIVAS_1",
+              "ref": "LEY C 024714 1996 10 02 0000 000 0000 000"
+            },
+            {
+              "cr": null,
+              "id": "REFERENCIAS_NORMATIVAS_2",
+              "ref": "CON C 000000 1994 08 22 0099 000 0000 000"
+            },
+            {
+              "cr": null,
+              "id": "REFERENCIAS_NORMATIVAS_3",
+              "ref": "LEY C 026122 2006 07 20 0002 000 0000 000"
+            },
+            {
+              "cr": null,
+              "id": "REFERENCIAS_NORMATIVAS_4",
+              "ref": "LEY C 026122 2006 07 20 0019 000 0020 000"
+            }
+          ]
+        },
+        "sancion": "LA PRESIDENTA DE LA NACION ARGENTINA EN ACUERDO GENERAL DE MINISTROS DECRETA:",
+        "texto": "Que a través de la Ley Nº 24.714 se instituyó con alcance nacional y obligatorio el Régimen de Asignaciones Familiares.\n\nQue dicha norma alcanza a los trabajadores que prestan servicios remunerados en relación de dependencia en la actividad privada, a los beneficiarios de la Prestación por Desempleo, de la Ley de Riesgos del Trabajo, del Sistema Integrado Previsional Argentino (SIPA) y de pensiones no contributivas por invalidez, como así también a los grupos familiares que se encuentren desocupados o que se desempeñen en la economía informal.\n\nQue resulta adecuada la adopción de políticas públicas que permitan mejorar la situación de los ámbitos más desprotegidos de la sociedad de manera simultánea con el crecimiento económico.\n\nQue el sistema de seguridad social es la principal herramienta de redistribución de los recursos, brindando cobertura a las contingencias sociales y protegiendo a los más necesitados.\n\nQue en este contexto debe priorizarse el análisis de la situación de cada grupo familiar.\n\nQue la familia es la célula básica de todas las sociedades y su protección genera mejores condiciones para la misma en su conjunto.\n\nQue es necesario concentrar la cobertura de las contingencias en el grupo familiar y, de esa manera, lograr una mejor redistribución del ingreso; focalizando las políticas públicas sobre aquellos sectores sociales que requieren atención prioritaria.\n\nQue en virtud de ello y con el ánimo de mejorar las condiciones de la población resulta necesario considerar, para el acceso a las prestaciones de la Ley Nº 24.714, los ingresos del grupo familiar en su conjunto.\n\nQue a través de esta modificación se contribuye a optimizar la administración de los recursos de la seguridad social, en un marco de equidad que permite otorgar las prestaciones a los sectores de la población que resultan de atención prioritaria.\n\nQue la particular naturaleza de la situación planteada y la urgencia requerida para su resolución, dificultan seguir los trámites ordinarios previstos por la CONSTITUCION NACIONAL para la sanción de las leyes, por lo que el PODER EJECUTIVO NACIONAL adopta la presente medida con carácter excepcional.\n\nQue la Ley Nº 26.122, regula el trámite y los alcances de la intervención del HONORABLE CONGRESO DE LA NACION respecto de los Decretos de Necesidad y Urgencia dictados por el PODER EJECUTIVO NACIONAL, en virtud de lo dispuesto por el artículo 99 inciso 3 de la CONSTITUCION NACIONAL. Que la citada ley determina, que la Comisión Bicameral Permanente tiene competencia para pronunciarse respecto de la validez o invalidez de los decretos de necesidad y urgencia, así como elevar el dictamen al plenario de cada Cámara para su expreso tratamiento, en el plazo de DIEZ (10) días hábiles.\n\nQue el artículo 20 de la Ley Nº 26.122 prevé incluso que, en el supuesto que la Comisión Bicameral Permanente no eleve el correspondiente despacho, las Cámaras se abocarán al expreso e inmediato tratamiento del decreto, de conformidad con lo establecido en los artículos 99, inciso 3 y 82 de la CONSTITUCION NACIONAL.\n\nQue, por su parte, el artículo 22 de la misma ley dispone que las Cámaras se pronuncien mediante sendas resoluciones y que el rechazo o aprobación de los decretos deberá ser expreso conforme lo establecido en el artículo 82 de la Carta Magna.\n\nQue ha tomado la intervención de su competencia el servicio jurídico permanente.\n\nQue la presente medida se dicta en uso de las facultades que otorga el artículo 99, inciso 3, de la CONSTITUCION NACIONAL y de los artículos 2°, 19 y 20 de la Ley Nº 26.122. Por ello,"
+      },
+      "articulo": [
+        {
+          "numero-articulo": 1,
+          "texto": "Artículo 1° - Los límites que condicionan el otorgamiento de las asignaciones familiares o la cuantía de las mismas, se calcularán en función de la totalidad de los ingresos correspondientes al grupo familiar.",
+          "observado-por": {
+            "referencia-normativa": [
+              {
+                "cr": "(B.O. 31/05/2013) SE ESTABLECE EL LIMITE DE INGRESOS MINIMO Y MAXIMO CORRESPONDIENTES AL GRUPO FAMILIAR EN PESOS DOSCIENTOS ($ 200.-) Y PESOS DIECISEIS MIL OCHOCIENTOS ($ 16.800.-) RESPSECTIVAMENTE",
+                "id": "OBSERVADO_POR_0",
+                "ref": "DEC C 000614 2013 05 30 0001 000 0000 000"
+              },
+              {
+                "cr": "(B.O. 17/3/2016) SE ESTABLECE El LIMITE DE INGRESOS MINIMO Y MAXIMO CORRESPONDIENTES AL GRUPO FAMILIAR EN PESOS DOSCIENTOS ($ 200.-) y PESOS SESENTA MIL ($60.000) RESPECTIVAMENTE",
+                "id": "OBSERVADO_POR_1",
+                "ref": "DEC C 000492 2016 03 16 0001 000 0000 000"
+              },
+              {
+                "cr": "(B.O. 27/9/2024) La percepción de un ingreso superior a ($1.799.733) por parte de una de las personas integrantes del grupo familiar excluye a dicho grupo del cobro de las asignaciones familiares, aun cuando la suma de sus ingresos no supere el límite máximo de ingresos establecido en los anexos de la presente por Resolución de la Anses",
+                "id": "OBSERVADO_POR_2",
+                "ref": "RES C 000840 2024 09 25 0001 000 0000 000"
+              }
+            ]
+          }
+        },
+        {
+          "referencias-normativas": {
+            "referencia-normativa": [
+              {
+                "cr": null,
+                "id": "REFERENCIAS_NORMATIVAS_0",
+                "ref": "LEY C 024013 1991 11 13 0000 000 0000 000"
+              },
+              {
+                "cr": null,
+                "id": "REFERENCIAS_NORMATIVAS_1",
+                "ref": "LEY C 024241 1993 09 23 0000 000 0000 000"
+              },
+              {
+                "cr": null,
+                "id": "REFERENCIAS_NORMATIVAS_2",
+                "ref": "LEY C 024557 1995 09 13 0000 000 0000 000"
+              },
+              {
+                "cr": null,
+                "id": "REFERENCIAS_NORMATIVAS_3",
+                "ref": "LEY C 024714 1996 10 02 0000 000 0000 000"
+              },
+              {
+                "cr": null,
+                "id": "REFERENCIAS_NORMATIVAS_4",
+                "ref": "LEY C 025191 1999 11 03 0000 000 0000 000"
+              }
+            ]
+          },
+          "numero-articulo": 2,
+          "texto": "Art. 2° - A los efectos de la aplicación del artículo 1° del presente Decreto, deben considerarse como ingresos, las remuneraciones de los trabajadores en relación de dependencia registrados, las rentas de referencia para trabajadores autónomos y monotributistas, las sumas originadas en Prestaciones Contributivas y/o No Contributivas Nacionales, Provinciales, Municipales o de la Ciudad Autónoma de Buenos Aires, incluyendo las prestaciones previstas en las Leyes Nros. 24.013, 24.241, 24.557, Nº 24.714 artículo 11, 25.191 y sus respectivas modificatorias y complementarias."
+        },
+        {
+          "numero-articulo": 3,
+          "texto": "Art. 3° - Facúltase a la ADMINISTRACION NACIONAL DE LA SEGURIDAD SOCIAL (ANSES) para que dicte las normas aclaratorias y complementarias necesarias para la implementación del presente decreto."
+        },
+        {
+          "numero-articulo": 4,
+          "texto": "Art. 4° - El presente decreto comenzará a regir a partir de las asignaciones familiares devengadas por el mes de septiembre de 2012."
+        },
+        {
+          "numero-articulo": 5,
+          "texto": "Art. 5° - Dése cuenta a la Comisión Bicameral Permanente del HONORABLE CONGRESO DE LA NACION."
+        },
+        {
+          "numero-articulo": 6,
+          "texto": "Art. 6° - Comuníquese, publíquese, dése a la Dirección Nacional del Registro Oficial y archívese."
+        }
+      ],
+      "firmantes": {
+        "firmantes": "FERNANDEZ DE KIRCHNER-Abal Medina-Randazzo-Garré-Lorenzino-Alak-Tomada-Kirchner-Manzur-Sileoni-Barañao-Meyer-Puricelli n - a a"
+      },
+      "id-infojus": "DN20120001667",
+      "fecha-umod": 20240927144423
+    }
+  }
+}

--- a/src/Tests/Argentina/SyncSummaryTests.cs
+++ b/src/Tests/Argentina/SyncSummaryTests.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Clarius.OpenLaw.Argentina;
+
+public class SyncSummaryTests(ITestOutputHelper output)
+{
+    [Fact]
+    public async Task DiffOmitsTimestampChanges()
+    {
+        var newDoc = await Document.ParseAsync(File.ReadAllText(@$"../../../Argentina/SaijSamples/Diff/123456789-0abc-095-0000-7991soterced-new.json"));
+        var oldDoc = await Document.ParseAsync(File.ReadAllText(@$"../../../Argentina/SaijSamples/Diff/123456789-0abc-095-0000-7991soterced-old.json"));
+
+        var result = new SyncActionResult(ContentAction.Updated, newDoc, oldDoc);
+        var summary = new SyncSummary("Testing");
+        summary.Add(result);
+
+        var markdown = summary.ToMarkdown();
+
+        Assert.DoesNotContain("<details>", markdown);
+    }
+
+    [Fact]
+    public async Task DiffIncludesChangedDoc()
+    {
+        var newDoc = await Document.ParseAsync(File.ReadAllText(@$"../../../Argentina/SaijSamples/Diff/123456789-0abc-766-1000-2102soterced-new.json"));
+        var oldDoc = await Document.ParseAsync(File.ReadAllText(@$"../../../Argentina/SaijSamples/Diff/123456789-0abc-766-1000-2102soterced-old.json"));
+
+        var result = new SyncActionResult(ContentAction.Updated, newDoc, oldDoc);
+        var summary = new SyncSummary("Testing");
+        summary.Add(result);
+
+        var markdown = summary.ToMarkdown();
+
+        Assert.Contains("<details>", markdown);
+    }
+}


### PR DESCRIPTION
If the sync action for a document was a non-trivial change (i.e. not just timestamps updating), emit details of the updated docs.