### PR TITLE
Make usage of lowercase for command options consistent

### DIFF
--- a/src/OpenLaw/Argentina/ClientSettings.cs
+++ b/src/OpenLaw/Argentina/ClientSettings.cs
@@ -11,12 +11,12 @@ public class ClientSettings : CommandSettings
     [DefaultValue(TipoNorma.Ley)]
     public TipoNorma? Tipo { get; set; } = TipoNorma.Ley;
 
-    [DisplayValueDescription<Jurisdiccion>("Jurisdicción a sincronizar")]
+    [DisplayValueDescription<Jurisdiccion>("Jurisdicción a sincronizar", lowerCase: true)]
     [CommandOption("-j|--jurisdiccion")]
     [DefaultValue(Argentina.Jurisdiccion.Nacional)]
     public Jurisdiccion? Jurisdiccion { get; set; } = Argentina.Jurisdiccion.Nacional;
 
-    [EnumDescription<Provincia>("Provincia a sincronizar")]
+    [EnumDescription<Provincia>("Provincia a sincronizar", lowerCase: true)]
     [CommandOption("-p|--provincia")]
     [DefaultValue(null)]
     public Provincia? Provincia { get; set; }

--- a/src/OpenLaw/Argentina/Provincia.cs
+++ b/src/OpenLaw/Argentina/Provincia.cs
@@ -1,4 +1,6 @@
-﻿namespace Clarius.OpenLaw.Argentina;
+﻿using System.ComponentModel;
+
+namespace Clarius.OpenLaw.Argentina;
 
 public enum Provincia
 {
@@ -10,6 +12,7 @@ public enum Provincia
     [DisplayValue("Ciudad Autónoma de Buenos Aires")]
     [DisplayValue("Ciudad Autonoma de Buenos Aires")]
     [DisplayValue("CABA")]
+    [Description("CABA")]
     CiudadAutonomaDeBuenosAires,
     [DisplayValue("Córdoba")]
     Cordoba,

--- a/src/OpenLaw/DisplayValueConverter.cs
+++ b/src/OpenLaw/DisplayValueConverter.cs
@@ -11,6 +11,6 @@ class DisplayValueConverter<TEnum> : EnumConverter where TEnum : struct, Enum
         => sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
 
     public override object? ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object value)
-        => value.ToString() is string display && DisplayValue.TryParse<TEnum>(display, out var result) ? result
+        => value.ToString() is string display && DisplayValue.TryParse<TEnum>(display, true, out var result) ? result
         : base.ConvertFrom(context, culture, value);
 }

--- a/src/OpenLaw/DisplayValueDescriptionAttribute.cs
+++ b/src/OpenLaw/DisplayValueDescriptionAttribute.cs
@@ -3,11 +3,11 @@ using System.Reflection;
 
 namespace Clarius.OpenLaw;
 
-class DisplayValueDescriptionAttribute<TEnum>(string description, bool parenthesize = true)
-    : DescriptionAttribute(GetDescription(description, parenthesize))
+class DisplayValueDescriptionAttribute<TEnum>(string description, bool parenthesize = true, bool lowerCase = false)
+    : DescriptionAttribute(GetDescription(description, parenthesize, lowerCase))
     where TEnum : struct, Enum
 {
-    static readonly List<string> names = [.. Enum
+    static readonly List<string> original = [.. Enum
         .GetNames<TEnum>()
         .Select(name => typeof(TEnum).GetField(name))
         .Where(field => field != null)
@@ -15,8 +15,10 @@ class DisplayValueDescriptionAttribute<TEnum>(string description, bool parenthes
             // This attribute allows multiple.
             field!.GetCustomAttributes<DisplayValueAttribute>().Select(x => x.Value).FirstOrDefault() ??
             field!.GetCustomAttribute<DescriptionAttribute>()?.Description ??
-            field!.Name.ToLowerInvariant())];
+            field!.Name)];
 
-    static string GetDescription(string description, bool parenthesize) => description.Trim() + " " +
-        (parenthesize ? $"({string.Join(", ", names)})" : string.Join(", ", names));
+    static readonly List<string> lowerCased = [.. original.Select(x => x.ToLowerInvariant())];
+
+    static string GetDescription(string description, bool parenthesize, bool lowerCase) => description.Trim() + " " +
+        (parenthesize ? $"({string.Join(", ", lowerCase ? lowerCased : original)})" : string.Join(", ", lowerCase ? lowerCased : original));
 }

--- a/src/OpenLaw/EnumDescriptionAttribute.cs
+++ b/src/OpenLaw/EnumDescriptionAttribute.cs
@@ -3,11 +3,11 @@ using System.Reflection;
 
 namespace Clarius.OpenLaw;
 
-class EnumDescriptionAttribute<TEnum>(string description, bool parenthesize = true)
-    : DescriptionAttribute(GetDescription(description, parenthesize))
+class EnumDescriptionAttribute<TEnum>(string description, bool parenthesize = true, bool lowerCase = false)
+    : DescriptionAttribute(GetDescription(description, parenthesize, lowerCase))
     where TEnum : struct, Enum
 {
-    static readonly List<string> names = [.. Enum
+    static readonly List<string> original = [.. Enum
         .GetNames<TEnum>()
         .Select(name => typeof(TEnum).GetField(name))
         .Where(field => field != null)
@@ -15,6 +15,8 @@ class EnumDescriptionAttribute<TEnum>(string description, bool parenthesize = tr
             field!.GetCustomAttribute<DescriptionAttribute>()?.Description ??
             field!.Name.ToLowerInvariant())];
 
-    static string GetDescription(string description, bool parenthesize) => description.Trim() + " " +
-        (parenthesize ? $"({string.Join(", ", names)})" : string.Join(", ", names));
+    static readonly List<string> lowerCased = [.. original.Select(x => x.ToLowerInvariant())];
+
+    static string GetDescription(string description, bool parenthesize, bool lowerCase) => description.Trim() + " " +
+        (parenthesize ? $"({string.Join(", ", lowerCase ? lowerCased : original)})" : string.Join(", ", lowerCase ? lowerCased : original));
 }

--- a/src/dotnet-openlaw/sync.md
+++ b/src/dotnet-openlaw/sync.md
@@ -12,10 +12,9 @@ OPTIONS:
                                       resolucion, disposicion, decision,        
                                       acordada)                                 
     -j, --jurisdiccion    Nacional    Jurisdicción a sincronizar (nacional,     
-                                      internacional, Local, federal)            
+                                      internacional, local, federal)            
     -p, --provincia                   Provincia a sincronizar (buenosaires,     
-                                      catamarca, chaco, chubut,                 
-                                      ciudadautonomadebuenosaires, cordoba,     
+                                      catamarca, chaco, chubut, caba, cordoba,  
                                       corrientes, entrerios, formosa, jujuy,    
                                       lapampa, larioja, mendoza, misiones,      
                                       neuquen, rionegro, salta, sanjuan,        


### PR DESCRIPTION
Shorten CABA too.