### PR TITLE
Content type "novedad" is typically empty and a pointer

### DIFF
--- a/src/OpenLaw/Argentina/ClientSettings.cs
+++ b/src/OpenLaw/Argentina/ClientSettings.cs
@@ -21,6 +21,11 @@ public class ClientSettings : CommandSettings
     [DefaultValue(null)]
     public Provincia? Provincia { get; set; }
 
+    [EnumDescription<ContentType>("Tipo de contenido a sincronizar", lowerCase: true)]
+    [DefaultValue(ContentType.Legislacion)]
+    [CommandOption("-c|--content-type")]
+    public ContentType ContentType { get; set; } = ContentType.Legislacion;
+
     [Description("Filtros avanzados a aplicar (KEY=VALUE)")]
     [CommandOption("-f|--filtro")]
     public Dictionary<string, string> Filters { get; set; } = [];

--- a/src/OpenLaw/Argentina/SyncCommand.cs
+++ b/src/OpenLaw/Argentina/SyncCommand.cs
@@ -66,6 +66,9 @@ public class SyncCommand(IAnsiConsole console, IHttpClientFactory http) : AsyncC
                                 if (settings.Top != null && results.Count >= settings.Top)
                                     return;
 
+                                if (item.ContentType != settings.ContentType)
+                                    continue;
+
                                 results.Enqueue(new SyncAction(client, item, target,
                                    await target.GetTimestampAsync(item.Id), settings.Force));
 

--- a/src/dotnet-openlaw/sync.md
+++ b/src/dotnet-openlaw/sync.md
@@ -7,25 +7,27 @@ USAGE:
 
 OPTIONS:
                           DEFAULT                                               
-    -h, --help                        Prints help information                   
-    -t, --tipo            Ley         Tipo de norma a sincronizar (ley, decreto,
-                                      resolucion, disposicion, decision,        
-                                      acordada)                                 
-    -j, --jurisdiccion    Nacional    Jurisdicción a sincronizar (nacional,     
-                                      internacional, local, federal)            
-    -p, --provincia                   Provincia a sincronizar (buenosaires,     
-                                      catamarca, chaco, chubut, caba, cordoba,  
-                                      corrientes, entrerios, formosa, jujuy,    
-                                      lapampa, larioja, mendoza, misiones,      
-                                      neuquen, rionegro, salta, sanjuan,        
-                                      sanluis, santacruz, santafe,              
-                                      santiagodelestero, tierradelfuego,        
-                                      tucuman)                                  
-    -f, --filtro                      Filtros avanzados a aplicar (KEY=VALUE)   
-        --vigente                     Mostrar solo leyes/decretos vigentes      
-        --dir                         Ubicación opcional archivos. Por defecto  
-                                      el directorio actual                      
-        --changelog                   Escribir un resumen de las operaciones    
-                                      efectuadas en el archivo especificado     
-        --appendlog                   Agregar al log de cambios si ya existe    
+    -h, --help                           Prints help information                
+    -t, --tipo            Ley            Tipo de norma a sincronizar (ley,      
+                                         decreto, resolucion, disposicion,      
+                                         decision, acordada)                    
+    -j, --jurisdiccion    Nacional       Jurisdicción a sincronizar (nacional,  
+                                         internacional, local, federal)         
+    -p, --provincia                      Provincia a sincronizar (buenosaires,  
+                                         catamarca, chaco, chubut, caba,        
+                                         cordoba, corrientes, entrerios,        
+                                         formosa, jujuy, lapampa, larioja,      
+                                         mendoza, misiones, neuquen, rionegro,  
+                                         salta, sanjuan, sanluis, santacruz,    
+                                         santafe, santiagodelestero,            
+                                         tierradelfuego, tucuman)               
+    -c, --content-type    Legislacion    Tipo de contenido a sincronizar        
+                                         (legislacion, novedad)                 
+    -f, --filtro                         Filtros avanzados a aplicar (KEY=VALUE)
+        --vigente                        Mostrar solo leyes/decretos vigentes   
+        --dir                            Ubicación opcional archivos. Por       
+                                         defecto el directorio actual           
+        --changelog                      Escribir un resumen de las operaciones 
+                                         efectuadas en el archivo especificado  
+        --appendlog                      Agregar al log de cambios si ya existe 
 ```


### PR DESCRIPTION
See https://github.com/search?q=repo%3Aclarius/normas%20path%3ANV&type=code.

We'd rather just keep actual legislation changes. So for now, disable the content type altogether like we do for other unsupported ones.