### PR TITLE
Fix bug in .content.fecha where it's a number

### DIFF
--- a/src/OpenLaw/Argentina/SaijDocument.jq
+++ b/src/OpenLaw/Argentina/SaijDocument.jq
@@ -1,3 +1,8 @@
+def to_fecha:
+  if . == null then null
+  else if type == "number" then tostring | if length == 4 then . + "-01-01" else . end else . end
+  end;
+
 def to_timestamp:
   if . == null then null
   elif type == "number" then .
@@ -48,10 +53,10 @@ def refs($context; $name):
     summary: (.content.sintesis // ([.content.sumario | .. | select(type == "string")] | join("")) | ltrimstr(" ") | rtrimstr(" ")),
     kind: .content["tipo-norma"] | { code: .codigo, text: .texto },
     status: (.content.estado // .content.status),
-    date: .content.fecha,
+    date: .content.fecha | to_fecha,
     modified: (
         (.content["fecha-umod"]? | select(. != null) | tostring | .[0:4] + "-" + .[4:6] + "-" + .[6:8]) // 
-        .content.fecha
+        (.content.fecha? | to_fecha)
     ),
     timestamp: (
         (
@@ -64,7 +69,7 @@ def refs($context; $name):
         ) // 
         (.content["timestamp-m"]? | select(. != null) | . + "Z" | to_timestamp) //
         (.content["timestamp"]? | select(. != null) | . + "Z" | to_timestamp) //
-        (.content.fecha? | select(. != null) | . + "T00:00:00Z" | to_timestamp) //
+        (.content.fecha? | to_fecha | select(. != null) | . + "T00:00:00Z" | to_timestamp) //
         (.metadata.timestamp | to_timestamp)
     ),
     terms: [

--- a/src/OpenLaw/Argentina/SaijTimestamp.jq
+++ b/src/OpenLaw/Argentina/SaijTimestamp.jq
@@ -1,3 +1,8 @@
+def to_fecha:
+  if . == null then null
+  else if type == "number" then tostring | if length == 4 then . + "-01-01" else . end else . end
+  end;
+
 def to_timestamp:
   if . == null then null
   elif type == "number" then .
@@ -16,5 +21,5 @@ def to_timestamp:
     ) // 
     (.content["timestamp-m"]? | select(. != null) | . + "Z" | to_timestamp) //
     (.content["timestamp"]? | select(. != null) | . + "Z" | to_timestamp) //
-    (.content.fecha? | select(. != null) | . + "T00:00:00Z" | to_timestamp) //
+    (.content.fecha? | to_fecha | select(. != null) | . + "T00:00:00Z" | to_timestamp) //
     (.metadata.timestamp | to_timestamp)

--- a/src/OpenLaw/Argentina/SearchResult.jq
+++ b/src/OpenLaw/Argentina/SearchResult.jq
@@ -1,4 +1,9 @@
-﻿def to_timestamp:
+﻿def to_fecha:
+  if . == null then null
+  else if type == "number" then tostring | if length == 4 then . + "-01-01" else . end else . end
+  end;
+
+def to_timestamp:
   if . == null then null
   elif type == "number" then .
   else
@@ -9,7 +14,7 @@
     id: .metadata.uuid,
     contentType: .metadata["document-content-type"], 
     documentType: .content["tipo-norma"] | { code: .codigo, text: .texto },
-    date: .content.fecha,
+    date: .content.fecha? | to_fecha,
     status: (.content.estado // .content.status),
     timestamp: (
         (


### PR DESCRIPTION
Some entries have the year as a plain number (i.e. 1977). Since we use that as a date, we must turn it into a string, and we now add Jan-1 as month/day as default.