### PR TITLE
Improve cancellation, fix parallelism bug on paging

### DIFF
--- a/src/OpenLaw/App.cs
+++ b/src/OpenLaw/App.cs
@@ -63,6 +63,16 @@ public static class App
             Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
         });
 
+        var shutdownSource = new CancellationTokenSource();
+        System.Console.CancelKeyPress += (s, e) =>
+        {
+            // We stop from main loop after we do graceful shutdown
+            e.Cancel = true;
+            shutdownSource.Cancel();
+        };
+
+        collection.AddSingleton(shutdownSource);
+
         collection.UseArgentina();
 
         var registrar = new TypeRegistrar(collection);

--- a/src/OpenLaw/Argentina/EnumerateCommand.cs
+++ b/src/OpenLaw/Argentina/EnumerateCommand.cs
@@ -9,7 +9,7 @@ using Spectre.Console.Cli;
 namespace Clarius.OpenLaw.Argentina;
 
 [Description("Enumerar todos los documentos.")]
-public class EnumerateCommand(IAnsiConsole console, IHttpClientFactory http) : AsyncCommand<EnumerateCommand.EnumerateSettings>
+public class EnumerateCommand(IAnsiConsole console, IHttpClientFactory http, CancellationTokenSource cts) : AsyncCommand<EnumerateCommand.EnumerateSettings>
 {
     // For batched retrieval from search results.
     const int PageSize = 100;
@@ -42,6 +42,7 @@ public class EnumerateCommand(IAnsiConsole console, IHttpClientFactory http) : A
 
                 var options = new ParallelOptions
                 {
+                    CancellationToken = cts.Token,
                     MaxDegreeOfParallelism = Debugger.IsAttached ? 1 : Environment.ProcessorCount
                 };
 

--- a/src/OpenLaw/Argentina/SaijClient.cs
+++ b/src/OpenLaw/Argentina/SaijClient.cs
@@ -50,6 +50,7 @@ public class SaijClient(IHttpClientFactory httpFactory, IProgress<ProgressMessag
             foreach (var item in result.Docs)
             {
                 count++;
+                cancellation.ThrowIfCancellationRequested();
 
                 // This is the bare minimum we expect all results to have.
                 if (await JQ.ExecuteAsync(item.Abstract, ThisAssembly.Resources.Argentina.SaijIdType.Text) is not { } idType ||


### PR DESCRIPTION
--skip flag was not being very well used. Parallel per-CPU skip pages weren't working optimally, and we were potentially doing work multiple times per item (wrong skip calculation).