### PR TITLE
Add general purpose system id mapper

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,6 +71,11 @@ jobs:
       - name: 🙏 build
         run: dotnet build -m:1 -bl:build.binlog
 
+      - name: ⚙ azurite
+        run: |
+          npm install azurite
+          npx azurite &
+
       - name: 🧪 test
         run: |
           dotnet tool update -g dotnet-retest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,6 +33,11 @@ jobs:
       - name: 🙏 build
         run: dotnet build -m:1 -bl:build.binlog
 
+      - name: ⚙ azurite
+        run: |
+          npm install azurite
+          npx azurite &
+
       - name: 🧪 test
         run: |
           dotnet tool update -g dotnet-retest

--- a/src/OpenLaw/OpenLaw.csproj
+++ b/src/OpenLaw/OpenLaw.csproj
@@ -7,9 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Devlooped.TableStorage" Version="5.2.1" />
     <PackageReference Include="NuGetizer" Version="1.2.4" PrivateAssets="all" />
     <PackageReference Include="SystemTextJson.JsonDiffPatch" Version="2.0.0" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
+    <PackageReference Include="Devlooped.Extensions.DependencyInjection.Attributed" Version="2.0.0" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/src/OpenLaw/SystemIdMapper.cs
+++ b/src/OpenLaw/SystemIdMapper.cs
@@ -1,0 +1,62 @@
+﻿using Azure.Data.Tables;
+using Devlooped;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Clarius.OpenLaw;
+
+/// <summary>
+/// Represents an identifier within a given system.
+/// </summary>
+public record SystemId(string System, string Id)
+{
+    public static implicit operator SystemId((string System, string Id) tuple) => new(tuple.System, tuple.Id);
+    public static implicit operator (string System, string Id)(SystemId mapping) => (mapping.System, mapping.Id);
+}
+
+/// <summary>
+/// Maps IDs across different systems.
+/// </summary>
+[Service]
+public class SystemIdMapper(CloudStorageAccount storage)
+{
+    readonly ITableRepository<TableEntity> repo = TableRepository.Create(storage, "SystemId");
+
+    /// <summary>
+    /// Creates a bidirectional mapping between the two identifiers.
+    /// </summary>
+    /// <param name="first">First System-scoped identifier.</param>
+    /// <param name="second">Second System-scoped identifier.</param>
+    /// <param name="cancellation">Optional cancellation token.</param>
+    public async Task MapAsync(SystemId first, SystemId second, CancellationToken cancellation = default)
+    {
+        await repo.PutAsync(new TableEntity($"{first.System}-{first.Id}", $"{second.System}-{second.Id}"), cancellation);
+        await repo.PutAsync(new TableEntity($"{second.System}-{second.Id}", $"{first.System}-{first.Id}"), cancellation);
+    }
+
+    /// <summary>
+    /// Tries to find the identifier in the target <paramref name="system"/> that matches the given 
+    /// source <paramref name="from"/> identifier and system.
+    /// </summary>
+    /// <param name="from">The system identifier to map from.</param>
+    /// <param name="system">The target system to find the map for.</param>
+    /// <returns>The mapped identifier or <see langword="null"/> if no mapping exists.</returns>
+    public async Task<string?> FindAsync(SystemId from, string system)
+    {
+        var key = $"{from.System}-{from.Id}";
+        var query = from item in repo.CreateQuery()
+                    where item.PartitionKey == key && item.RowKey.CompareTo(system) >= 0
+                    select item;
+
+        try
+        {
+            await foreach (var item in query.Take(1))
+                return item.RowKey[(system.Length + 1)..];
+        }
+        catch (HttpRequestException re) when (re.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            // no value found in this case.
+        }
+
+        return default;
+    }
+}

--- a/src/Tests/SystemIdMapperTests.cs
+++ b/src/Tests/SystemIdMapperTests.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Devlooped;
+
+namespace Clarius.OpenLaw;
+
+public class SystemIdMapperTests
+{
+    [Fact]
+    public async Task Map()
+    {
+        var mapper = new SystemIdMapper(CloudStorageAccount.DevelopmentStorageAccount);
+        var from = ("github", "123");
+        var to = ("discord", "456");
+
+        await mapper.MapAsync(from, to);
+        await mapper.MapAsync(from, ("chebot", "asdf"));
+
+        Assert.Equal("456", await mapper.FindAsync(from, "discord"));
+        Assert.Equal("asdf", await mapper.FindAsync(from, "chebot"));
+
+        // Test reverse mappings too, leverage tuple conversion
+        Assert.Equal("123", await mapper.FindAsync(("chebot", "asdf"), "github"));
+        Assert.Equal("123", await mapper.FindAsync(("discord", "456"), "chebot"));
+    }
+}


### PR DESCRIPTION
We'll need to map across WhatsApp, OpenLaw and Grok/OpenAI conversations, so we implement a generic mechanism to accomodate them all.

The service is append-only since IDs are permanent and stable.